### PR TITLE
Upgrade to PSPDFKit framework 5.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,47 @@ pspdfkit.password=YOUR_PASSWORD_GOES_HERE
 flutter.buildMode=debug
 ```
 
-5. Open `myapp/android/app/build.gradle` and modify line 27 from `minSdkVersion 16` to `minSdkVersion 19`.
+5. Open `myapp/android/app/build.gradle` and modify `compileSdkVersion` from `27` to `28`, `minSdkVersion` from `16` to `19`, `targetSdkVersion` from `27` to `28` and add compile options to enable desugaring 
+  
+  ```groovy
+  compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
+  ```
+  
+**Four changes** to edit:
+
+```diff
+...
+android {
+-   compileSdkVersion 27
++   compileSdkVersion 28
+    
++    compileOptions {
++       sourceCompatibility 1.8
++       targetCompatibility 1.8
++   }
+
+    lintOptions {
+        disable 'InvalidPackage'
+    }
+
+    defaultConfig {
+        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
+        applicationId "com.pspdfkit.myapp.myapp2"
+-       minSdkVersion 16
++       minSdkVersion 19
+-       targetSdkVersion 27
++       targetSdkVersion 28
+        versionCode flutterVersionCode.toInteger()
+        versionName flutterVersionName
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    }
+...
+```
+
+
 6. Open `myapp/lib/main.dart` and replace the whole content with a simple example that will load a pdf document from local device filesystem
 
 ```dart

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "com.pspdfkit.myapp.myapp2"
+        applicationId "com.example.myapp"
 -       minSdkVersion 16
 +       minSdkVersion 19
 -       targetSdkVersion 27

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Let's create a simple app that integrates PSPDFKit and uses the Flutter pspdfkit
 4. Open `myapp/android/local.properties` and specify the following properties
 
 ```local.properties
-ndk.dir=/path/to/your/Android/sdk/ndk-bundle
 sdk.dir=/path/to/your/Android/sdk
 flutter.sdk=/path/to/your/flutter/sdk
 pspdfkit.password=YOUR_PASSWORD_GOES_HERE

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,11 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion androidCompileSdkVersion
     buildToolsVersion androidBuildToolsVersion
+    
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
 
     defaultConfig {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/android/config.gradle
+++ b/android/config.gradle
@@ -36,13 +36,13 @@ if (pspdfkitIsDemo == null) {
 ext.pspdfkitMavenModuleName = pspdfkitIsDemo ? 'pspdfkit-demo' : 'pspdfkit'
 ext.pspdfkitVersion = localProperties.getProperty('pspdfkit.version')
 if (pspdfkitVersion == null || pspdfkitVersion == '') {
-    ext.pspdfkitVersion = '4.7.0'
+    ext.pspdfkitVersion = '5.0.1'
 }
 
 ext.pspdfkitFlutterVersion = '1.0.0-SNAPSHOT'
 
-ext.androidCompileSdkVersion = 27
-ext.androidBuildToolsVersion = '27.0.3'
+ext.androidCompileSdkVersion = 28
+ext.androidBuildToolsVersion = '28.0.3'
 ext.androidMinSdkVersion = 19
-ext.androidTargetSdkVersion = 27
+ext.androidTargetSdkVersion = 28
 ext.androidGradlePluginVersion = '3.1.3'

--- a/android/config.gradle
+++ b/android/config.gradle
@@ -45,4 +45,4 @@ ext.androidCompileSdkVersion = 28
 ext.androidBuildToolsVersion = '28.0.3'
 ext.androidMinSdkVersion = 19
 ext.androidTargetSdkVersion = 28
-ext.androidGradlePluginVersion = '3.1.3'
+ext.androidGradlePluginVersion = '3.2.1'

--- a/example/README.md
+++ b/example/README.md
@@ -1,3 +1,22 @@
 # PSPDFKit Flutter Example 
 
 This is a brief example of how to use the PSPDFKit with Flutter.
+
+# Running Example Project
+
+1. Clone the repository `git clone https://github.com/PSPDFKit/pspdfkit-flutter.git`
+
+2. Create a local property file in `pspdfkit-flutter/example/android/local.properties` and specify the following properties
+```local.properties
+sdk.dir=/path/to/your/Android/sdk
+flutter.sdk=/path/to/your/flutter/sdk
+pspdfkit.password=YOUR_PASSWORD_GOES_HERE
+flutter.buildMode=debug
+```
+
+3. Before launching the app you need to copy a PDF document onto your development device or emulator
+```bash
+adb push /path/to/your/document.pdf /sdcard/document.pdf
+```
+
+4. The app is ready to start! From `pspdfkit-flutter/example` run `flutter run`

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -20,18 +20,6 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-
-        // This is needed to help flutter decide which
-        // target compile the provided third party NDK libraries.
-        // https://github.com/flutter/flutter/issues/15733
-        // Once fixed this needs to become
-        // abiFilters 'arm64-v8a', 'armeabi-v7a'
-        // Note Flutter currently does not support building for x86 Android (issue #9253) directly,
-        // however apps built for ARMv7 or ARM64 run fine
-        // via ARM emulation on many x86 Android devices.
-        ndk {
-            abiFilters 'armeabi-v7a'
-        }
     }
 
     buildTypes {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -3,6 +3,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion androidCompileSdkVersion
+    
+    compileOptions {
+      sourceCompatibility 1.8
+      targetCompatibility 1.8
+    }
 
     lintOptions {
         disable 'InvalidPackage'

--- a/example/android/local.properties.sample
+++ b/example/android/local.properties.sample
@@ -3,6 +3,7 @@
 ndk.dir=/path/to/your/android/ndk
 sdk.dir=/path/to/your/android/sdk
 flutter.sdk=/path/to/your/flutter/sdk
+flutter.buildMode=debug
 
 # The Maven password you received while together with your PSPDFKit demo email, or your customer Maven password.
 # If you don't yet own a password, please head over to https://pspdfkit.com/try to request a demo.

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,5 +1,10 @@
 name: pspdfkit_example
 description: Demonstrates how to use the pspdfkit plugin.
+version: 0.1.0
+author: PSPDFKit
+homepage: https://pspdfkit.com/
+environment:
+  sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
   flutter:
@@ -26,34 +31,3 @@ flutter:
   # included with your application, so that you can use the icons in
   # the material Icons class.
   uses-material-design: true
-
-  # To add assets to your application, add an assets section, like this:
-  # assets:
-  #  - images/a_dot_burr.jpeg
-  #  - images/a_dot_ham.jpeg
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.io/assets-and-images/#resolution-aware.
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.io/assets-and-images/#from-packages
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies, 
-  # see https://flutter.io/custom-fonts/#from-packages

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,10 @@
 name: pspdfkit
 description: PSPDFKit flutter plugin.
-version: 0.0.1
-author:
-homepage:
+version: 0.1.0
+author: PSPDFKit
+homepage: https://pspdfkit.com/
+environment:
+  sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
   flutter:
@@ -16,34 +18,3 @@ flutter:
   plugin:
     androidPackage: com.pspdfkit.flutter.pspdfkit
     pluginClass: PspdfkitPlugin
-
-  # To add assets to your plugin package, add an assets section, like this:
-  # assets:
-  #  - images/a_dot_burr.jpeg
-  #  - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.io/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.io/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your plugin package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.io/custom-fonts/#from-packages


### PR DESCRIPTION
This PR upgrades PSPDFKit framework version to `5.0.1` and adds other minor improvements:
* Adds `environment` field to `pubspec.yaml` required as of Dart 2
* Adds compatible options to enable desugaring required for compiling with Java 8
* Improves template for `local.properties.sample`
* Upgrades Android Gradle plugin version to `3.2.1`
* Removes the abi filter workaround previously added to fix a [known bug](https://github.com/flutter/flutter/issues/15733)
* Updates the [main README.md](https://github.com/PSPDFKit/pspdfkit-flutter/blob/master/README.md)
* Updates the [example project README.md](https://github.com/PSPDFKit/pspdfkit-flutter/blob/master/example/README.md)