### PR TITLE
Add Swift Version in the Podspec

### DIFF
--- a/ios/pspdfkit_flutter.podspec
+++ b/ios/pspdfkit_flutter.podspec
@@ -16,7 +16,7 @@ PSPDFKit flutter plugin.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'PSPDFKit'
-  
+  s.swift_version = '4.2'
   s.ios.deployment_target = '10.0'
 end
 


### PR DESCRIPTION
# Details

Having swift version missing caused an issue when using the most recent version of Flutter. See Z-13104.

## How to Reproduce:

* Make sure you are using the most recent version of Flutter.
* Fresh clone the repo.
* Follow the instructions to run the example project: https://github.com/PSPDFKit/pspdfkit-flutter/tree/master/example#running-the-example-project

## Expected:

The example project should run without any issues.

## Actual:

💥 It fails during `pod install`:

```sh

...
`pspdfkit_flutter` does not specify a Swift version and none of the targets (`Runner`) integrating it have the `SWIFT_VERSION` attribute set. Please contact the author or set the `SWIFT_VERSION` attribute in at least one of the targets that integrate this pod
...
```

# Acceptance Criteria

- [x] The example project should run without any issues after a fresh clone.
