### PR TITLE
Extend support for styling and configuration options for iOS

### DIFF
--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		134B9D554906601BF25ED5F2 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1589BBAD9A55430A9716182C /* Pods_Runner.framework */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
-		2D5378261FAA1A9400D5DBA9 /* flutter_assets in Resources */ = {isa = PBXBuildFile; fileRef = 2D5378251FAA1A9400D5DBA9 /* flutter_assets */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		3B80C3941E831B6300D905FE /* App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; };
 		3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -41,9 +40,9 @@
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		1589BBAD9A55430A9716182C /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		2D5378251FAA1A9400D5DBA9 /* flutter_assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = flutter_assets; path = Flutter/flutter_assets; sourceTree = SOURCE_ROOT; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		3B80C3931E831B6300D905FE /* App.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = App.framework; path = Flutter/App.framework; sourceTree = "<group>"; };
+		7680CF0EE621C4C588CA8319 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		7AFFD8ED1D35381100E5BB4D /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -56,6 +55,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		EA8AE65FF465391772EFF6C0 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -83,7 +83,6 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
-				2D5378251FAA1A9400D5DBA9 /* flutter_assets */,
 				3B80C3931E831B6300D905FE /* App.framework */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEBA1CF902C7004384FC /* Flutter.framework */,
@@ -140,6 +139,8 @@
 		D20A32FD2B4A9D4673751062 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
+				7680CF0EE621C4C588CA8319 /* Pods-Runner.debug.xcconfig */,
+				EA8AE65FF465391772EFF6C0 /* Pods-Runner.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -209,7 +210,6 @@
 				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
-				2D5378261FAA1A9400D5DBA9 /* flutter_assets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -239,7 +239,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
 				"${PODS_ROOT}/../.symlinks/flutter/ios/Flutter.framework",
 				"${PODS_ROOT}/PSPDFKit/PSPDFKit.framework",
 				"${PODS_ROOT}/PSPDFKit/PSPDFKit.framework.dSYM",
@@ -262,7 +262,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {

--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -77,24 +77,14 @@
     }
     
     return [configuration configurationUpdatedWithBuilder:^(PSPDFConfigurationBuilder * _Nonnull builder) {
-        if (dictionary[@"pageScrollDirection"]) {
-            builder.scrollDirection = [dictionary[@"pageScrollDirection"] isEqualToString:@"pageScrollDirectionHorizontal"] ? PSPDFScrollDirectionHorizontal : PSPDFScrollDirectionVertical;
-        }
-        if (dictionary[@"pageScrollContinuous"]) {
-            builder.pageTransition = dictionary[@"pageScrollContinuous"] ? PSPDFPageTransitionScrollContinuous : PSPDFPageTransitionScrollPerSpread;
-        }
-        if (dictionary[@"userInterfaceViewMode"]) {
-            builder.userInterfaceViewMode = [self userInterfaceViewMode:dictionary];
-        }
-        if (dictionary[@"inlineSearch"]) {
-            builder.searchMode = dictionary[@"inlineSearch"] ? PSPDFSearchModeInline : PSPDFSearchModeModal;
-        }
-        if (dictionary[@"showThumbnailBar"]) {
-            builder.thumbnailBarMode = [self thumbnailBarMode:dictionary];
-        }
-        if (dictionary[@"showPageLabels"]) {
-            builder.pageLabelEnabled = [dictionary[@"showPageLabels"] boolValue];
-        }
+        builder.scrollDirection = [dictionary[@"pageScrollDirection"] isEqualToString:@"vertical"] ? PSPDFScrollDirectionVertical : PSPDFScrollDirectionHorizontal;
+        builder.pageTransition = [dictionary[@"scrollContinuously"] boolValue] ? PSPDFPageTransitionScrollContinuous : PSPDFPageTransitionScrollPerSpread;
+        builder.spreadFitting = [dictionary[@"fitPageToWidth"] boolValue] ? PSPDFConfigurationSpreadFittingFill : PSPDFConfigurationSpreadFittingAdaptive;
+        builder.searchMode = [dictionary[@"inlineSearch"] boolValue] ? PSPDFSearchModeInline : PSPDFSearchModeModal;
+        builder.pageLabelEnabled = [dictionary[@"showPageLabels"] boolValue];
+        builder.userInterfaceViewMode = [self userInterfaceViewMode:dictionary];
+        builder.thumbnailBarMode = [self thumbnailBarMode:dictionary];
+
         if (![dictionary[@"enableAnnotationEditing"] boolValue]) {
             builder.editableAnnotationTypes = nil;
         }
@@ -107,11 +97,11 @@
 # pragma mark - Helpers
 
 - (PSPDFUserInterfaceViewMode)userInterfaceViewMode:(NSDictionary *)dictionary {
+    PSPDFUserInterfaceViewMode userInterfaceMode = PSPDFConfiguration.defaultConfiguration.userInterfaceViewMode;
     if ((id)dictionary == NSNull.null || !dictionary || dictionary.count == 0) {
-        return PSPDFUserInterfaceViewModeAutomatic;
+        return userInterfaceMode;
     }
 
-    PSPDFUserInterfaceViewMode userInterfaceMode = PSPDFUserInterfaceViewModeAutomatic;
     NSString *value = dictionary[@"userInterfaceViewMode"];
     if (value) {
         if ([value isEqualToString:@"automatic"]) {
@@ -128,11 +118,11 @@
 }
 
 - (PSPDFThumbnailBarMode)thumbnailBarMode:(NSDictionary *)dictionary {
+    PSPDFThumbnailBarMode thumbnailBarMode = PSPDFConfiguration.defaultConfiguration.thumbnailBarMode;
     if ((id)dictionary == NSNull.null || !dictionary || dictionary.count == 0) {
-        return PSPDFThumbnailBarModeScrubberBar;
+        return thumbnailBarMode;
     }
 
-    PSPDFThumbnailBarMode thumbnailBarMode = PSPDFThumbnailBarModeScrubberBar;
     NSString *value = dictionary[@"showThumbnailBar"];
     if (value) {
         if ([value isEqualToString:@"default"]) {

--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -84,13 +84,13 @@
             builder.pageTransition = dictionary[@"pageScrollContinuous"] ? PSPDFPageTransitionScrollContinuous : PSPDFPageTransitionScrollPerSpread;
         }
         if (dictionary[@"userInterfaceViewMode"]) {
-            builder.userInterfaceViewMode = [self userInterfaceViewMode:dictionary[@"userInterfaceViewMode"]];
+            builder.userInterfaceViewMode = [self userInterfaceViewMode:dictionary];
         }
         if (dictionary[@"inlineSearch"]) {
             builder.searchMode = dictionary[@"inlineSearch"] ? PSPDFSearchModeInline : PSPDFSearchModeModal;
         }
         if (dictionary[@"showThumbnailBar"]) {
-            builder.thumbnailBarMode = [self thumbnailBarMode:dictionary[@"showThumbnailBar"]];
+            builder.thumbnailBarMode = [self thumbnailBarMode:dictionary];
         }
         if (dictionary[@"showPageLabels"]) {
             builder.pageLabelEnabled = [dictionary[@"showPageLabels"] boolValue];
@@ -106,38 +106,44 @@
 
 # pragma mark - Helpers
 
-- (PSPDFUserInterfaceViewMode)userInterfaceViewMode:(NSString *)stringValue {
-    if ((id)stringValue == NSNull.null || !stringValue || stringValue.length == 0) {
+- (PSPDFUserInterfaceViewMode)userInterfaceViewMode:(NSDictionary *)dictionary {
+    if ((id)dictionary == NSNull.null || !dictionary || dictionary.count == 0) {
         return PSPDFUserInterfaceViewModeAutomatic;
-    } else {
-        PSPDFUserInterfaceViewMode userInterfaceMode = PSPDFUserInterfaceViewModeAutomatic;
-        if ([stringValue isEqualToString:@"automatic"]) {
+    }
+
+    PSPDFUserInterfaceViewMode userInterfaceMode = PSPDFUserInterfaceViewModeAutomatic;
+    NSString *value = dictionary[@"userInterfaceViewMode"];
+    if (value) {
+        if ([value isEqualToString:@"automatic"]) {
             userInterfaceMode = PSPDFUserInterfaceViewModeAutomatic;
-        } else if ([stringValue isEqualToString:@"alwaysVisible"]) {
+        } else if ([value isEqualToString:@"alwaysVisible"]) {
             userInterfaceMode = PSPDFUserInterfaceViewModeAlways;
-        } else if ([stringValue isEqualToString:@"alwaysHidden"]) {
+        } else if ([value isEqualToString:@"alwaysHidden"]) {
             userInterfaceMode = PSPDFUserInterfaceViewModeNever;
-        } else if ([stringValue isEqualToString:@"automaticNoFirstLastPage"]) {
+        } else if ([value isEqualToString:@"automaticNoFirstLastPage"]) {
             userInterfaceMode = PSPDFUserInterfaceViewModeAutomaticNoFirstLastPage;
         }
-        return  userInterfaceMode;
     }
+    return userInterfaceMode;
 }
 
-- (PSPDFThumbnailBarMode)thumbnailBarMode:(NSString *)stringValue {
-    if ((id)stringValue == NSNull.null || !stringValue || stringValue.length == 0) {
+- (PSPDFThumbnailBarMode)thumbnailBarMode:(NSDictionary *)dictionary {
+    if ((id)dictionary == NSNull.null || !dictionary || dictionary.count == 0) {
         return PSPDFThumbnailBarModeScrubberBar;
-    } else {
-        PSPDFThumbnailBarMode thumbnailBarMode = PSPDFThumbnailBarModeScrubberBar;
-        if ([stringValue isEqualToString:@"default"]) {
+    }
+
+    PSPDFThumbnailBarMode thumbnailBarMode = PSPDFThumbnailBarModeScrubberBar;
+    NSString *value = dictionary[@"showThumbnailBar"];
+    if (value) {
+        if ([value isEqualToString:@"default"]) {
             thumbnailBarMode = PSPDFThumbnailBarModeScrubberBar;
-        } else if ([stringValue isEqualToString:@"scrollable"]) {
+        } else if ([value isEqualToString:@"scrollable"]) {
             thumbnailBarMode = PSPDFThumbnailBarModeScrollable;
-        } else if ([stringValue isEqualToString:@"none"]) {
+        } else if ([value isEqualToString:@"none"]) {
             thumbnailBarMode = PSPDFThumbnailBarModeNone;
         }
-        return thumbnailBarMode;
     }
+    return thumbnailBarMode;
 }
 
 
@@ -146,8 +152,8 @@
         return PSPDFAppearanceModeDefault;
     }
     PSPDFAppearanceMode appearanceMode = PSPDFAppearanceModeDefault;
-    if (dictionary[@"appearanceMode"]) {
-        NSString *value = dictionary[@"appearanceMode"];
+    NSString *value = dictionary[@"appearanceMode"];
+    if (value) {
         if ([value isEqualToString:@"default"]) {
             appearanceMode = PSPDFAppearanceModeDefault;
         } else if ([value isEqualToString:@"night"]) {

--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -150,7 +150,7 @@
 }
 
 - (BOOL)isImageDocument:(NSString*)path {
-    NSString *fileExtension = path.lowercaseString.pathExtension;
+    NSString *fileExtension = path.pathExtension.lowercaseString;
     return [fileExtension isEqualToString:@"png"] || [fileExtension isEqualToString:@"jpeg"] || [fileExtension isEqualToString:@"jpg"];
 }
 


### PR DESCRIPTION
# Details

This PR adds the ability to set some basic PSPDFConfiguration option when presenting the document. It also adds the ability to set the appearance mode.

![recording](https://user-images.githubusercontent.com/7443038/55277861-19762780-52db-11e9-9c50-16a807636c10.gif)

Since we want the have a consistent Dart API, we decided to use the shared naming for the configuration options defined here: https://github.com/PSPDFKit/pspdfkit-flutter/blob/master/lib/configuration_options.dart

Also, for example on iOS, the appearance mode is not set in `PSPDFConfiguration`, we set it to the PSPDFViewController's appearance mode manager, like so: https://pspdfkit.com/guides/ios/current/customizing-the-interface/appearance-mode-manager/?#appearance-mode

# Acceptance Criteria

- [x] Adds the ability to set some basic PSPDFConfiguration option when presenting the document.
- [x] Adds the ability to set the appearance mode