### PR TITLE
Extend configuration options to add `showDocumentTitle` + Add the ability to customize the toolbar buttons in the configuration

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -125,6 +125,7 @@ class _MyAppState extends State<MyApp> {
         androidShowAnnotationListAction: true,
         showPageNumberOverlay: false,
         showPageLabels: true,
+        showDocumentLabel: false,
         invertColors: false,
         grayScale: false,
         startPage: 2,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -125,7 +125,7 @@ class _MyAppState extends State<MyApp> {
         androidShowAnnotationListAction: true,
         showPageNumberOverlay: false,
         showPageLabels: true,
-        showDocumentTitle: true,
+        showDocumentTitle: false,
         invertColors: false,
         grayScale: false,
         startPage: 2,
@@ -136,7 +136,7 @@ class _MyAppState extends State<MyApp> {
         showDocumentInfoView: true,
         appearanceMode: appearanceModeDefault,
         androidDefaultThemeResource: 'PSPDFKit.Theme.Example',
-        iOSRightBarButtonItems:['thumbnailsButtonItem', 'searchButtonItem', 'annotationButtonItem'],
+        iOSRightBarButtonItems:['thumbnailsButtonItem', 'activityButtonItem', 'searchButtonItem', 'annotationButtonItem'],
         iOSLeftBarButtonItems:['settingsButtonItem']
       });
     } on PlatformException catch (e) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -135,7 +135,9 @@ class _MyAppState extends State<MyApp> {
         androidShowPrintAction: false,
         showDocumentInfoView: true,
         appearanceMode: appearanceModeDefault,
-        androidDefaultThemeResource: 'PSPDFKit.Theme.Example'
+        androidDefaultThemeResource: 'PSPDFKit.Theme.Example',
+        iOSRightBarButtonItems:['thumbnailsButtonItem', 'searchButtonItem', 'annotationButtonItem'],
+        iOSLeftBarButtonItems:['settingsButtonItem']
       });
     } on PlatformException catch (e) {
       print("Failed to open document: '${e.message}'.");

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -125,7 +125,7 @@ class _MyAppState extends State<MyApp> {
         androidShowAnnotationListAction: true,
         showPageNumberOverlay: false,
         showPageLabels: true,
-        showDocumentLabel: false,
+        showDocumentTitle: true,
         invertColors: false,
         grayScale: false,
         startPage: 2,

--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -11,6 +11,10 @@
 @import PSPDFKit;
 @import PSPDFKitUI;
 
+@interface PspdfkitPlugin()
+@property (nonatomic) PSPDFViewController *pdfViewController;
+@end
+
 @implementation PspdfkitPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
     FlutterMethodChannel* channel = [FlutterMethodChannel
@@ -35,11 +39,13 @@
         PSPDFDocument *document = [self document:documentPath];
         [self unlockWithPasswordIfNeeded:document dictionary:configurationDictionary];
         PSPDFConfiguration *psPdfConfiguration = [self configuration:configurationDictionary isImageDocument:[self isImageDocument:documentPath]];
-        PSPDFViewController *pdfViewController = [[PSPDFViewController alloc] initWithDocument:document configuration:psPdfConfiguration];
-        pdfViewController.appearanceModeManager.appearanceMode = [self appearanceMode:configurationDictionary];
-        pdfViewController.pageIndex = [self pageIndex:configurationDictionary];
-        
-        UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:pdfViewController];
+        self.pdfViewController = [[PSPDFViewController alloc] initWithDocument:document configuration:psPdfConfiguration];
+        self.pdfViewController.appearanceModeManager.appearanceMode = [self appearanceMode:configurationDictionary];
+        self.pdfViewController.pageIndex = [self pageIndex:configurationDictionary];
+        [self setLeftBarButtonItems:configurationDictionary[@"leftBarButtonItems"]];
+        [self setRightBarButtonItems:configurationDictionary[@"rightBarButtonItems"]];
+
+        UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:self.pdfViewController];
         UIViewController *presentingViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
         [presentingViewController presentViewController:navigationController animated:YES completion:nil];
     } else {
@@ -95,6 +101,40 @@
         }
     }];
 }
+
+
+#pragma mark - Customize the Toolbar
+
+- (void)setLeftBarButtonItems:(nullable NSArray <NSString *> *)items {
+    if ((id)items == NSNull.null || !items || items.count == 0) {
+        return;
+    }
+    NSMutableArray *leftItems = [NSMutableArray array];
+    for (NSString *barButtonItemString in items) {
+        UIBarButtonItem *barButtonItem = [self uiBarButtonItemFrom:barButtonItemString forViewController:self.pdfViewController];
+        if (barButtonItem && ![self.pdfViewController.navigationItem.rightBarButtonItems containsObject:barButtonItem]) {
+            [leftItems addObject:barButtonItem];
+        }
+    }
+
+    [self.pdfViewController.navigationItem setLeftBarButtonItems:[leftItems copy] animated:NO];
+}
+
+- (void)setRightBarButtonItems:(nullable NSArray <NSString *> *)items {
+    if ((id)items == NSNull.null || !items || items.count == 0) {
+        return;
+    }
+    NSMutableArray *rightItems = [NSMutableArray array];
+    for (NSString *barButtonItemString in items) {
+        UIBarButtonItem *barButtonItem = [self uiBarButtonItemFrom:barButtonItemString forViewController:self.pdfViewController];
+        if (barButtonItem && ![self.pdfViewController.navigationItem.leftBarButtonItems containsObject:barButtonItem]) {
+            [rightItems addObject:barButtonItem];
+        }
+    }
+
+    [self.pdfViewController.navigationItem setRightBarButtonItems:[rightItems copy] animated:NO];
+}
+
 
 # pragma mark - Helpers
 
@@ -176,6 +216,40 @@
     NSString *password = dictionary[@"password"];
     if (password.length) {
         [document unlockWithPassword:password];
+    }
+}
+
+- (UIBarButtonItem *)uiBarButtonItemFrom:(NSString *)barButtonItem forViewController:(PSPDFViewController *)pdfController {
+    if ([barButtonItem isEqualToString:@"closeButtonItem"]) {
+        return pdfController.closeButtonItem;
+    } else if ([barButtonItem isEqualToString:@"outlineButtonItem"]) {
+        return pdfController.outlineButtonItem;
+    } else if ([barButtonItem isEqualToString:@"searchButtonItem"]) {
+        return pdfController.searchButtonItem;
+    } else if ([barButtonItem isEqualToString:@"thumbnailsButtonItem"]) {
+        return pdfController.thumbnailsButtonItem;
+    } else if ([barButtonItem isEqualToString:@"documentEditorButtonItem"]) {
+        return pdfController.documentEditorButtonItem;
+    } else if ([barButtonItem isEqualToString:@"printButtonItem"]) {
+        return pdfController.printButtonItem;
+    } else if ([barButtonItem isEqualToString:@"openInButtonItem"]) {
+        return pdfController.openInButtonItem;
+    } else if ([barButtonItem isEqualToString:@"emailButtonItem"]) {
+        return pdfController.emailButtonItem;
+    } else if ([barButtonItem isEqualToString:@"messageButtonItem"]) {
+        return pdfController.messageButtonItem;
+    } else if ([barButtonItem isEqualToString:@"annotationButtonItem"]) {
+        return pdfController.annotationButtonItem;
+    } else if ([barButtonItem isEqualToString:@"bookmarkButtonItem"]) {
+        return pdfController.bookmarkButtonItem;
+    } else if ([barButtonItem isEqualToString:@"brightnessButtonItem"]) {
+        return pdfController.brightnessButtonItem;
+    } else if ([barButtonItem isEqualToString:@"activityButtonItem"]) {
+        return pdfController.activityButtonItem;
+    } else if ([barButtonItem isEqualToString:@"settingsButtonItem"]) {
+        return pdfController.settingsButtonItem;
+    } else {
+        return nil;
     }
 }
 

--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -219,7 +219,7 @@
     }
 }
 
-- (UIBarButtonItem *)uiBarButtonItemFrom:(NSString *)barButtonItem forViewController:(PSPDFViewController *)pdfController {
+- (UIBarButtonItem *)barButtonItemFromString:(NSString *)barButtonItem forViewController:(PSPDFViewController *)pdfController {
     if ([barButtonItem isEqualToString:@"closeButtonItem"]) {
         return pdfController.closeButtonItem;
     } else if ([barButtonItem isEqualToString:@"outlineButtonItem"]) {

--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -83,6 +83,7 @@
         builder.spreadFitting = [dictionary[@"fitPageToWidth"] boolValue] ? PSPDFConfigurationSpreadFittingFill : PSPDFConfigurationSpreadFittingAdaptive;
         builder.searchMode = [dictionary[@"inlineSearch"] boolValue] ? PSPDFSearchModeInline : PSPDFSearchModeModal;
         builder.pageLabelEnabled = [dictionary[@"showPageLabels"] boolValue];
+        builder.documentLabelEnabled = [dictionary[@"showDocumentLabel"] boolValue];
         builder.userInterfaceViewMode = [self userInterfaceViewMode:dictionary];
         builder.thumbnailBarMode = [self thumbnailBarMode:dictionary];
 

--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -89,7 +89,7 @@
         builder.spreadFitting = [dictionary[@"fitPageToWidth"] boolValue] ? PSPDFConfigurationSpreadFittingFill : PSPDFConfigurationSpreadFittingAdaptive;
         builder.searchMode = [dictionary[@"inlineSearch"] boolValue] ? PSPDFSearchModeInline : PSPDFSearchModeModal;
         builder.pageLabelEnabled = [dictionary[@"showPageLabels"] boolValue];
-        builder.documentLabelEnabled = [dictionary[@"showDocumentLabel"] boolValue];
+        builder.documentLabelEnabled = [dictionary[@"showDocumentTitle"] boolValue];
         builder.userInterfaceViewMode = [self userInterfaceViewMode:dictionary];
         builder.thumbnailBarMode = [self thumbnailBarMode:dictionary];
 

--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -111,7 +111,7 @@
     }
     NSMutableArray *leftItems = [NSMutableArray array];
     for (NSString *barButtonItemString in items) {
-        UIBarButtonItem *barButtonItem = [self uiBarButtonItemFrom:barButtonItemString forViewController:self.pdfViewController];
+        UIBarButtonItem *barButtonItem = [self barButtonItemFromString:barButtonItemString forViewController:self.pdfViewController];
         if (barButtonItem && ![self.pdfViewController.navigationItem.rightBarButtonItems containsObject:barButtonItem]) {
             [leftItems addObject:barButtonItem];
         }
@@ -126,7 +126,7 @@
     }
     NSMutableArray *rightItems = [NSMutableArray array];
     for (NSString *barButtonItemString in items) {
-        UIBarButtonItem *barButtonItem = [self uiBarButtonItemFrom:barButtonItemString forViewController:self.pdfViewController];
+        UIBarButtonItem *barButtonItem = [self barButtonItemFromString:barButtonItemString forViewController:self.pdfViewController];
         if (barButtonItem && ![self.pdfViewController.navigationItem.leftBarButtonItems containsObject:barButtonItem]) {
             [rightItems addObject:barButtonItem];
         }

--- a/lib/configuration_options.dart
+++ b/lib/configuration_options.dart
@@ -76,3 +76,6 @@ const String androidDarkThemeResource = "darkThemeResource";
 const String androidDefaultThemeResource = "defaultThemeResource";
 
 const String password = "password";
+
+const String iOSLeftBarButtonItems = "leftBarButtonItems";
+const String iOSRightBarButtonItems = "rightBarButtonItems";

--- a/lib/configuration_options.dart
+++ b/lib/configuration_options.dart
@@ -48,7 +48,7 @@ const String showPageNumberOverlay = "showPageNumberOverlay";
 
 const String showPageLabels = "showPageLabels";
 
-const String showDocumentLabel = "showDocumentLabel";
+const String showDocumentTitle = "showDocumentTitle";
 
 const String invertColors = "invertColors";
 

--- a/lib/configuration_options.dart
+++ b/lib/configuration_options.dart
@@ -48,6 +48,8 @@ const String showPageNumberOverlay = "showPageNumberOverlay";
 
 const String showPageLabels = "showPageLabels";
 
+const String showDocumentLabel = "showDocumentLabel";
+
 const String invertColors = "invertColors";
 
 const String grayScale = "grayScale";


### PR DESCRIPTION
Came out in Z#14797. See #21 for the Android implementation

---

- [x] Implement `showDocumentTitle` in the iOS Configuration.
- [x] Adds the ability to customize the iOS toolbar.

## Usage:

```dart
Pspdfkit.present(documentPath, {
  showDocumentTitle: false,
  iOSRightBarButtonItems:['thumbnailsButtonItem', 'searchButtonItem', 'annotationButtonItem'],
  iOSLeftBarButtonItems:['settingsButtonItem']
});
```

<img width="584" alt="Screen Shot 2019-07-12 at 8 14 41 AM" src="https://user-images.githubusercontent.com/7443038/61127601-b40b0880-a47d-11e9-8599-96218a54f676.png">
