### PR TITLE
Adds Dart API to allow to override the toolbar title

### DIFF
--- a/android/src/main/java/com/pspdfkit/flutter/pspdfkit/ConfigurationAdapter.java
+++ b/android/src/main/java/com/pspdfkit/flutter/pspdfkit/ConfigurationAdapter.java
@@ -52,7 +52,7 @@ class ConfigurationAdapter {
     private static final String ANDROID_SHOW_ANNOTATION_LIST_ACTION = "showAnnotationListAction";
     private static final String SHOW_PAGE_NUMBER_OVERLAY = "showPageNumberOverlay";
     private static final String SHOW_PAGE_LABELS = "showPageLabels";
-    private static final String SHOW_DOCUMENT_TITLE = "showDocumentTitle";
+    private static final String SHOW_DOCUMENT_LABEL = "showDocumentLabel";
     private static final String INVERT_COLORS = "invertColors";
     private static final String GRAY_SCALE = "grayScale";
     private static final String START_PAGE = "startPage";
@@ -117,8 +117,8 @@ class ConfigurationAdapter {
             if (containsKeyOfType(configurationMap, SHOW_PAGE_LABELS, Boolean.class)) {
                 configureShowPageLabels((Boolean) configurationMap.get(SHOW_PAGE_LABELS));
             }
-            if (containsKeyOfType(configurationMap, SHOW_DOCUMENT_TITLE, Boolean.class)) {
-                configureShowDocumentTitle((Boolean) configurationMap.get(SHOW_DOCUMENT_TITLE));
+            if (containsKeyOfType(configurationMap, SHOW_DOCUMENT_LABEL, Boolean.class)) {
+                configureShowDocumentLabel((Boolean) configurationMap.get(SHOW_DOCUMENT_LABEL));
             }
             if (containsKeyOfType(configurationMap, GRAY_SCALE, Boolean.class)) {
                 configureGrayScale((Boolean) configurationMap.get(GRAY_SCALE));
@@ -270,8 +270,8 @@ class ConfigurationAdapter {
         }
     }
 
-    private void configureShowDocumentTitle(boolean showDocumentTitle) {
-        if (showDocumentTitle) {
+    private void configureShowDocumentLabel(boolean showDocumentLabel) {
+        if (showDocumentLabel) {
             configuration.showDocumentTitleOverlay();
         } else {
             configuration.hideDocumentTitleOverlay();

--- a/android/src/main/java/com/pspdfkit/flutter/pspdfkit/ConfigurationAdapter.java
+++ b/android/src/main/java/com/pspdfkit/flutter/pspdfkit/ConfigurationAdapter.java
@@ -53,6 +53,7 @@ class ConfigurationAdapter {
     private static final String SHOW_PAGE_NUMBER_OVERLAY = "showPageNumberOverlay";
     private static final String SHOW_PAGE_LABELS = "showPageLabels";
     private static final String SHOW_DOCUMENT_LABEL = "showDocumentLabel";
+    private static final String TOOLBAR_TITLE = "toolbarTitle";
     private static final String INVERT_COLORS = "invertColors";
     private static final String GRAY_SCALE = "grayScale";
     private static final String START_PAGE = "startPage";
@@ -119,6 +120,9 @@ class ConfigurationAdapter {
             }
             if (containsKeyOfType(configurationMap, SHOW_DOCUMENT_LABEL, Boolean.class)) {
                 configureShowDocumentLabel((Boolean) configurationMap.get(SHOW_DOCUMENT_LABEL));
+            }
+            if (containsKeyOfType(configurationMap, TOOLBAR_TITLE, String.class)) {
+                configureToolbarTitle((String) configurationMap.get(TOOLBAR_TITLE));
             }
             if (containsKeyOfType(configurationMap, GRAY_SCALE, Boolean.class)) {
                 configureGrayScale((Boolean) configurationMap.get(GRAY_SCALE));
@@ -276,6 +280,10 @@ class ConfigurationAdapter {
         } else {
             configuration.hideDocumentTitleOverlay();
         }
+    }
+
+    private void configureToolbarTitle(@Nullable String toolbarTitle) {
+        configuration.title(toolbarTitle);
     }
 
     private void configureGrayScale(boolean grayScale) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -140,8 +140,8 @@ class _MyAppState extends State<MyApp> {
         androidDefaultThemeResource: 'PSPDFKit.Theme.Example',
         iOSRightBarButtonItems:['thumbnailsButtonItem', 'activityButtonItem', 'searchButtonItem', 'annotationButtonItem'],
         iOSLeftBarButtonItems:['settingsButtonItem'],
-		iOSAllowToolbarTitleChange: false,
-		toolbarTitle: 'Custom Title'
+        iOSAllowToolbarTitleChange: false,
+        toolbarTitle: null
       });
     } on PlatformException catch (e) {
       print("Failed to open document: '${e.message}'.");

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -125,7 +125,7 @@ class _MyAppState extends State<MyApp> {
         androidShowAnnotationListAction: true,
         showPageNumberOverlay: false,
         showPageLabels: true,
-        showDocumentTitle: false,
+        showDocumentLabel: false,
         invertColors: false,
         grayScale: false,
         startPage: 2,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -140,7 +140,8 @@ class _MyAppState extends State<MyApp> {
         androidDefaultThemeResource: 'PSPDFKit.Theme.Example',
         iOSRightBarButtonItems:['thumbnailsButtonItem', 'activityButtonItem', 'searchButtonItem', 'annotationButtonItem'],
         iOSLeftBarButtonItems:['settingsButtonItem'],
-        iOSAllowToolbarTitleChange: false
+		iOSAllowToolbarTitleChange: false,
+		toolbarTitle: 'Custom Title'
       });
     } on PlatformException catch (e) {
       print("Failed to open document: '${e.message}'.");

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -139,7 +139,8 @@ class _MyAppState extends State<MyApp> {
         appearanceMode: appearanceModeDefault,
         androidDefaultThemeResource: 'PSPDFKit.Theme.Example',
         iOSRightBarButtonItems:['thumbnailsButtonItem', 'activityButtonItem', 'searchButtonItem', 'annotationButtonItem'],
-        iOSLeftBarButtonItems:['settingsButtonItem']
+        iOSLeftBarButtonItems:['settingsButtonItem'],
+        iOSAllowToolbarTitleChange: false
       });
     } on PlatformException catch (e) {
       print("Failed to open document: '${e.message}'.");

--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -89,15 +89,18 @@
         builder.pageTransition = [dictionary[@"scrollContinuously"] boolValue] ? PSPDFPageTransitionScrollContinuous : PSPDFPageTransitionScrollPerSpread;
         builder.spreadFitting = [dictionary[@"fitPageToWidth"] boolValue] ? PSPDFConfigurationSpreadFittingFill : PSPDFConfigurationSpreadFittingAdaptive;
         builder.searchMode = [dictionary[@"inlineSearch"] boolValue] ? PSPDFSearchModeInline : PSPDFSearchModeModal;
-        builder.pageLabelEnabled = [dictionary[@"showPageLabels"] boolValue];
-        builder.documentLabelEnabled = [dictionary[@"showDocumentTitle"] boolValue];
         builder.userInterfaceViewMode = [self userInterfaceViewMode:dictionary];
         builder.thumbnailBarMode = [self thumbnailBarMode:dictionary];
 
+        if (dictionary[@"showPageLabels"]) {
+            builder.pageLabelEnabled = [dictionary[@"showPageLabels"] boolValue];
+        }
+        if (dictionary[@"showDocumentTitle"]) {
+            builder.documentLabelEnabled = [dictionary[@"showDocumentTitle"] boolValue];
+        }
         if (dictionary[@"allowToolbarTitleChange"]) {
             builder.allowToolbarTitleChange = [dictionary[@"allowToolbarTitleChange"] boolValue];
         }
-
         if (![dictionary[@"enableAnnotationEditing"] boolValue]) {
             builder.editableAnnotationTypes = nil;
         }

--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -92,7 +92,8 @@
         builder.documentLabelEnabled = [dictionary[@"showDocumentTitle"] boolValue];
         builder.userInterfaceViewMode = [self userInterfaceViewMode:dictionary];
         builder.thumbnailBarMode = [self thumbnailBarMode:dictionary];
-
+        builder.allowToolbarTitleChange = [dictionary[@"allowToolbarTitleChange"] boolValue];
+        
         if (![dictionary[@"enableAnnotationEditing"] boolValue]) {
             builder.editableAnnotationTypes = nil;
         }

--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -44,7 +44,7 @@
         self.pdfViewController.pageIndex = [self pageIndex:configurationDictionary];
         [self setLeftBarButtonItems:configurationDictionary[@"leftBarButtonItems"]];
         [self setRightBarButtonItems:configurationDictionary[@"rightBarButtonItems"]];
-        [self setToolbarTitle:configurationDictionary];
+        [self setToolbarTitle:configurationDictionary[@"toolbarTitle"]];
 
         UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:self.pdfViewController];
         UIViewController *presentingViewController = [UIApplication sharedApplication].delegate.window.rootViewController;

--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -213,17 +213,13 @@
 }
 
 - (void)setToolbarTitle:(NSString *)toolbarTitle {
-    if ((id)dictionary == NSNull.null || !dictionary || dictionary.count == 0) {
-        return;
-    }
-    NSString *title = dictionary[@"toolbarTitle"];
     // Early return if the toolbar title is not explicitly set in the configuration dictionary.
-    if (!title) {
+    if (!toolbarTitle) {
         return;
     }
 
     // We allow setting a null title.
-    self.pdfViewController.title = (id)title == NSNull.null ? nil : title;
+    self.pdfViewController.title = (id)toolbarTitle == NSNull.null ? nil : toolbarTitle;
 }
 
 - (BOOL)isImageDocument:(NSString*)path {

--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -44,6 +44,7 @@
         self.pdfViewController.pageIndex = [self pageIndex:configurationDictionary];
         [self setLeftBarButtonItems:configurationDictionary[@"leftBarButtonItems"]];
         [self setRightBarButtonItems:configurationDictionary[@"rightBarButtonItems"]];
+        [self setToolbarTitle:configurationDictionary];
 
         UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:self.pdfViewController];
         UIViewController *presentingViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
@@ -92,8 +93,11 @@
         builder.documentLabelEnabled = [dictionary[@"showDocumentTitle"] boolValue];
         builder.userInterfaceViewMode = [self userInterfaceViewMode:dictionary];
         builder.thumbnailBarMode = [self thumbnailBarMode:dictionary];
-        builder.allowToolbarTitleChange = [dictionary[@"allowToolbarTitleChange"] boolValue];
-        
+
+        if (dictionary[@"allowToolbarTitleChange"]) {
+            builder.allowToolbarTitleChange = [dictionary[@"allowToolbarTitleChange"] boolValue];
+        }
+
         if (![dictionary[@"enableAnnotationEditing"] boolValue]) {
             builder.editableAnnotationTypes = nil;
         }
@@ -203,6 +207,20 @@
         return 0;
     }
     return (PSPDFPageIndex)[dictionary[@"startPage"] unsignedLongValue];
+}
+
+- (void)setToolbarTitle:(NSDictionary *)dictionary {
+    if ((id)dictionary == NSNull.null || !dictionary || dictionary.count == 0) {
+        return;
+    }
+    NSString *title = dictionary[@"toolbarTitle"];
+    // Early return if the toolbar title is not explicitly set in the configuration dictionary.
+    if (!title) {
+        return;
+    }
+
+    // We allow setting a null title.
+    self.pdfViewController.title = (id)title == NSNull.null ? nil : title;
 }
 
 - (BOOL)isImageDocument:(NSString*)path {

--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -95,8 +95,8 @@
         if (dictionary[@"showPageLabels"]) {
             builder.pageLabelEnabled = [dictionary[@"showPageLabels"] boolValue];
         }
-        if (dictionary[@"showDocumentTitle"]) {
-            builder.documentLabelEnabled = [dictionary[@"showDocumentTitle"] boolValue];
+        if (dictionary[@"showDocumentLabel"]) {
+            builder.documentLabelEnabled = [dictionary[@"showDocumentLabel"] boolValue];
         }
         if (dictionary[@"allowToolbarTitleChange"]) {
             builder.allowToolbarTitleChange = [dictionary[@"allowToolbarTitleChange"] boolValue];

--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -212,7 +212,7 @@
     return (PSPDFPageIndex)[dictionary[@"startPage"] unsignedLongValue];
 }
 
-- (void)setToolbarTitle:(NSDictionary *)dictionary {
+- (void)setToolbarTitle:(NSString *)toolbarTitle {
     if ((id)dictionary == NSNull.null || !dictionary || dictionary.count == 0) {
         return;
     }

--- a/lib/configuration_options.dart
+++ b/lib/configuration_options.dart
@@ -85,3 +85,5 @@ const String iOSLeftBarButtonItems = "leftBarButtonItems";
 const String iOSRightBarButtonItems = "rightBarButtonItems";
 
 const String iOSAllowToolbarTitleChange = "allowToolbarTitleChange";
+
+const String toolbarTitle = "toolbarTitle";

--- a/lib/configuration_options.dart
+++ b/lib/configuration_options.dart
@@ -48,7 +48,7 @@ const String showPageNumberOverlay = "showPageNumberOverlay";
 
 const String showPageLabels = "showPageLabels";
 
-const String showDocumentTitle = "showDocumentTitle";
+const String showDocumentLabel = "showDocumentLabel";
 
 const String invertColors = "invertColors";
 

--- a/lib/configuration_options.dart
+++ b/lib/configuration_options.dart
@@ -83,3 +83,5 @@ const String password = "password";
 
 const String iOSLeftBarButtonItems = "leftBarButtonItems";
 const String iOSRightBarButtonItems = "rightBarButtonItems";
+
+const String iOSAllowToolbarTitleChange = "allowToolbarTitleChange";


### PR DESCRIPTION
Came up in Z#14797

---

# Details

This is a followup to #20 and #21. 

- Allows the document title to be completely hidden in the UI.
- Adds the `toolbarTitle` Dart property to override the toolbar title. 
- Renames the previously added `showDocumentTitle` to `showDocumentlabel`.

<img width="844" alt="Screen Shot 2019-07-16 at 7 59 33 AM" src="https://user-images.githubusercontent.com/7443038/61292602-addb9b80-a79f-11e9-8dca-3a81fadc4080.png">

## Usage

```dart
Pspdfkit.present(tempDocumentPath, {
  iOSAllowToolbarTitleChange: false,
  showDocumentlabel: false,
  toolbarTitle: 'Custom Title'
});
```

# Acceptance Criteria:

- [x] The document title can be customized on iOS.
- [ ] The document title can be customized on Android.
