### PR TITLE
Fix crash that occurred when we didn’t pass a configuration

### DIFF
--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -42,9 +42,12 @@
         self.pdfViewController = [[PSPDFViewController alloc] initWithDocument:document configuration:psPdfConfiguration];
         self.pdfViewController.appearanceModeManager.appearanceMode = [self appearanceMode:configurationDictionary];
         self.pdfViewController.pageIndex = [self pageIndex:configurationDictionary];
-        [self setLeftBarButtonItems:configurationDictionary[@"leftBarButtonItems"]];
-        [self setRightBarButtonItems:configurationDictionary[@"rightBarButtonItems"]];
-        [self setToolbarTitle:configurationDictionary[@"toolbarTitle"]];
+        
+        if ((id)configurationDictionary != NSNull.null) {
+            [self setLeftBarButtonItems:configurationDictionary[@"leftBarButtonItems"]];
+            [self setRightBarButtonItems:configurationDictionary[@"rightBarButtonItems"]];
+            [self setToolbarTitle:configurationDictionary[@"toolbarTitle"]];
+        }
 
         UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:self.pdfViewController];
         UIViewController *presentingViewController = [UIApplication sharedApplication].delegate.window.rootViewController;


### PR DESCRIPTION
# Details

Fixes crash that occurred when we didn’t pass a configuration.

## How to Reproduce:

* Launch the example project and open the "Basic Example".

## Expected:

The basic example should be shown.

## Actual:

💥 We crash.

```sh
2019-07-18 09:18:57.565293-0400 Runner[16125:241748] -[NSNull objectForKeyedSubscript:]: unrecognized selector sent to instance 0x10e62df28
```

# Acceptance Criteria

- [x] The crash is fixed.
- [x] This change does not impact Android.