### PR TITLE
Expose pageLayoutMode and isFirstPageAlwaysSingle configuration options

### DIFF
--- a/android/src/main/java/com/pspdfkit/flutter/pspdfkit/ConfigurationAdapter.java
+++ b/android/src/main/java/com/pspdfkit/flutter/pspdfkit/ConfigurationAdapter.java
@@ -19,6 +19,7 @@ import com.pspdfkit.configuration.activity.PdfActivityConfiguration;
 import com.pspdfkit.configuration.activity.ThumbnailBarMode;
 import com.pspdfkit.configuration.activity.UserInterfaceViewMode;
 import com.pspdfkit.configuration.page.PageFitMode;
+import com.pspdfkit.configuration.page.PageLayoutMode;
 import com.pspdfkit.configuration.page.PageScrollDirection;
 import com.pspdfkit.configuration.page.PageScrollMode;
 import com.pspdfkit.configuration.settings.SettingsMenuItemType;
@@ -35,6 +36,10 @@ import static io.flutter.util.Preconditions.checkNotNull;
 class ConfigurationAdapter {
     private static final String LOG_TAG = "ConfigurationAdapter";
 
+    private static final String PAGE_LAYOUT_MODE = "pageLayoutMode";
+    private static final String PAGE_LAYOUT_MODE_SINGLE = "single";
+    private static final String PAGE_LAYOUT_MODE_DOUBLE = "double";
+    private static final String PAGE_LAYOUT_MODE_AUTO = "automatic";
     private static final String PAGE_SCROLL_DIRECTION = "pageScrollDirection";
     private static final String PAGE_SCROLL_DIRECTION_HORIZONTAL = "horizontal";
     private static final String PAGE_SCROLL_DIRECTION_VERTICAL = "vertical";
@@ -76,8 +81,9 @@ class ConfigurationAdapter {
     private static final String ANDROID_DARK_THEME_RESOURCE = "darkThemeResource";
     private static final String ANDROID_DEFAULT_THEME_RESOURCE = "defaultThemeResource";
     private static final String PASSWORD = "password";
-    private static final String SETTINGS_MENU_ITEMS = "settingsMenuItems";
+    private static final String SETTINGS_MENU_ITEMS = "androidSettingsMenuItems";
     private static final String SHOW_ACTION_NAVIGATION_BUTTONS = "showActionNavigationButtons";
+    private static final String IS_FIRST_PAGE_ALWAYS_SINGLE = "isFirstPageAlwaysSingle";
 
     @NonNull private final PdfActivityConfiguration.Builder configuration;
     @Nullable private String password = null;
@@ -86,6 +92,9 @@ class ConfigurationAdapter {
                          @Nullable HashMap<String, Object> configurationMap) {
         this.configuration = new PdfActivityConfiguration.Builder(context);
         if (configurationMap != null && !configurationMap.isEmpty()) {
+            if (containsKeyOfType(configurationMap, PAGE_LAYOUT_MODE, String.class)) {
+                configurePageLayoutMode((String) configurationMap.get(PAGE_LAYOUT_MODE));
+            }
             if (containsKeyOfType(configurationMap, PAGE_SCROLL_DIRECTION, String.class)) {
                 configurePageScrollDirection((String) configurationMap.get(PAGE_SCROLL_DIRECTION));
             }
@@ -179,6 +188,9 @@ class ConfigurationAdapter {
             if (containsKeyOfType(configurationMap, PASSWORD, String.class)) {
                 this.password = ((String) configurationMap.get(PASSWORD));
             }
+            if (containsKeyOfType(configurationMap, IS_FIRST_PAGE_ALWAYS_SINGLE, Boolean.class)) {
+                configureFirstPageAlwaysSingle((Boolean) configurationMap.get(IS_FIRST_PAGE_ALWAYS_SINGLE));
+            }
         }
     }
 
@@ -187,6 +199,23 @@ class ConfigurationAdapter {
             configuration.showPageNumberOverlay();
         } else {
             configuration.hidePageNumberOverlay();
+        }
+    }
+
+    private void configurePageLayoutMode(@NonNull final String pageLayoutMode) {
+        requireNotNullNotEmpty(pageLayoutMode, "pageLayoutMode");
+        switch (pageLayoutMode) {
+            case PAGE_LAYOUT_MODE_AUTO:
+                configuration.layoutMode(PageLayoutMode.AUTO);
+                break;
+            case PAGE_LAYOUT_MODE_SINGLE:
+                configuration.layoutMode(PageLayoutMode.SINGLE);
+                break;
+            case PAGE_LAYOUT_MODE_DOUBLE:
+                configuration.layoutMode(PageLayoutMode.DOUBLE);
+                break;
+            default:
+                throw new IllegalArgumentException("Undefined page layout mode for " + pageLayoutMode);
         }
     }
 
@@ -221,24 +250,22 @@ class ConfigurationAdapter {
     private void configureUserInterfaceViewMode(@NonNull String userInterfaceViewMode) {
         requireNotNullNotEmpty(userInterfaceViewMode, "userInterfaceViewMode");
 
-        UserInterfaceViewMode result;
         switch (userInterfaceViewMode) {
             case USER_INTERFACE_VIEW_MODE_AUTOMATIC:
-                result = UserInterfaceViewMode.USER_INTERFACE_VIEW_MODE_AUTOMATIC;
+                configuration.setUserInterfaceViewMode(UserInterfaceViewMode.USER_INTERFACE_VIEW_MODE_AUTOMATIC);
                 break;
             case USER_INTERFACE_VIEW_MODE_AUTOMATIC_BORDER_PAGES:
-                result = UserInterfaceViewMode.USER_INTERFACE_VIEW_MODE_AUTOMATIC_BORDER_PAGES;
+                configuration.setUserInterfaceViewMode(UserInterfaceViewMode.USER_INTERFACE_VIEW_MODE_AUTOMATIC_BORDER_PAGES);
                 break;
             case USER_INTERFACE_VIEW_MODE_ALWAYS_VISIBLE:
-                result = UserInterfaceViewMode.USER_INTERFACE_VIEW_MODE_VISIBLE;
+                configuration.setUserInterfaceViewMode(UserInterfaceViewMode.USER_INTERFACE_VIEW_MODE_VISIBLE);
                 break;
             case USER_INTERFACE_VIEW_MODE_ALWAYS_HIDDEN:
-                result = UserInterfaceViewMode.USER_INTERFACE_VIEW_MODE_HIDDEN;
+                configuration.setUserInterfaceViewMode(UserInterfaceViewMode.USER_INTERFACE_VIEW_MODE_HIDDEN);
                 break;
             default:
                 throw new IllegalArgumentException("Undefined user interface view mode for " + userInterfaceViewMode);
         }
-        configuration.setUserInterfaceViewMode(result);
     }
 
     private void configureShowSearchAction(boolean showSearchAction) {
@@ -457,6 +484,10 @@ class ConfigurationAdapter {
             }
         }
         configuration.setSettingsMenuItems(settingsMenuItemTypes);
+    }
+
+    private void configureFirstPageAlwaysSingle(final boolean firstPageAlwaysSingle) {
+        configuration.firstPageAlwaysSingle(firstPageAlwaysSingle);
     }
 
     private <T> boolean containsKeyOfType(@NonNull HashMap<String, Object> configurationMap,

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -2,3 +2,4 @@ org.gradle.jvmargs=-Xmx1536M
 org.gradle.configureondemand=false
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableR8=true

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -146,8 +146,8 @@ class _MyAppState extends State<MyApp> {
         iOSSettingsMenuItems:['scrollDirection', 'pageTransition', 'appearance', 'brightness', 'pageMode', 'spreadFitting'],
         showActionNavigationButtons: false,
         iOSShowActionNavigationButtonLabels: false,
-        pageLayoutMode: 'automatic',
-        iOSIsFirstPageAlwaysSingle: false
+        pageLayoutMode: 'double',
+        isFirstPageAlwaysSingle: false
       });
     } on PlatformException catch (e) {
       print("Failed to present document: '${e.message}'.");

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -113,7 +113,7 @@ class _MyAppState extends State<MyApp> {
 
       Pspdfkit.present(tempDocumentPath, {
         pageScrollDirection: pageScrollDirectionVertical,
-        pageScrollContinuous: true,
+        pageScrollContinuous: false,
         fitPageToWidth: true,
         androidImmersiveMode: false,
         userInterfaceViewMode: userInterfaceViewModeAutomaticBorderPages,
@@ -147,7 +147,7 @@ class _MyAppState extends State<MyApp> {
         showActionNavigationButtons: false,
         iOSShowActionNavigationButtonLabels: false,
         pageLayoutMode: 'double',
-        isFirstPageAlwaysSingle: false
+        isFirstPageAlwaysSingle: true
       });
     } on PlatformException catch (e) {
       print("Failed to present document: '${e.message}'.");

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -144,7 +144,9 @@ class _MyAppState extends State<MyApp> {
         toolbarTitle: 'Custom Title',
         androidSettingsMenuItems:['theme', 'scrolldirection'],
         showActionNavigationButtons: false,
-        iOSShowActionNavigationButtonLabels: false
+        iOSShowActionNavigationButtonLabels: false,
+        pageLayoutMode: 'automatic',
+        iOSIsFirstPageAlwaysSingle: false
       });
     } on PlatformException catch (e) {
       print("Failed to present document: '${e.message}'.");

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -143,6 +143,7 @@ class _MyAppState extends State<MyApp> {
         iOSAllowToolbarTitleChange: false,
         toolbarTitle: 'Custom Title',
         androidSettingsMenuItems:['theme', 'scrolldirection'],
+        iOSSettingsMenuItems:['scrollDirection', 'pageTransition', 'appearance', 'brightness', 'pageMode', 'spreadFitting'],
         showActionNavigationButtons: false,
         iOSShowActionNavigationButtonLabels: false,
         pageLayoutMode: 'automatic',

--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -108,6 +108,7 @@
         builder.searchMode = [dictionary[@"inlineSearch"] boolValue] ? PSPDFSearchModeInline : PSPDFSearchModeModal;
         builder.userInterfaceViewMode = [self userInterfaceViewMode:dictionary];
         builder.thumbnailBarMode = [self thumbnailBarMode:dictionary];
+        builder.pageMode = [self pageMode:dictionary];
 
         if (dictionary[@"showPageLabels"]) {
             builder.pageLabelEnabled = [dictionary[@"showPageLabels"] boolValue];
@@ -130,6 +131,9 @@
         }
         if (dictionary[@"iOSShowActionNavigationButtonLabels"]) {
             builder.showBackForwardActionButtonLabels = [dictionary[@"iOSShowActionNavigationButtonLabels"] boolValue];
+        }
+        if (dictionary[@"isFirstPageAlwaysSingle"]) {
+            builder.firstPageAlwaysSingle = [dictionary[@"isFirstPageAlwaysSingle"] boolValue];
         }
     }];
 }
@@ -305,6 +309,26 @@
         return 0;
     }
     return (PSPDFPageIndex)[dictionary[@"startPage"] unsignedLongValue];
+}
+
+- (PSPDFPageMode)pageMode:(NSDictionary *)dictionary {
+    PSPDFPageMode pageMode = PSPDFConfiguration.defaultConfiguration.pageMode;
+
+    if ((id)dictionary == NSNull.null || !dictionary || dictionary.count == 0) {
+        return pageMode;
+    }
+
+    NSString *value = dictionary[@"pageLayoutMode"];
+    if (value) {
+        if ([value isEqualToString:@"automatic"]) {
+            pageMode = PSPDFPageModeAutomatic;
+        } else if ([value isEqualToString:@"single"]) {
+            pageMode = PSPDFPageModeSingle;
+        } else if ([value isEqualToString:@"double"]) {
+            pageMode = PSPDFPageModeDouble;
+        }
+    }
+    return pageMode;
 }
 
 - (void)setToolbarTitle:(NSString *)toolbarTitle {

--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -135,6 +135,9 @@
         if (dictionary[@"isFirstPageAlwaysSingle"]) {
             builder.firstPageAlwaysSingle = [dictionary[@"isFirstPageAlwaysSingle"] boolValue];
         }
+        if (dictionary[@"settingsMenuItems"]) {
+            builder.settingsOptions = [self settingsOptions:dictionary[@"settingsMenuItems"]];
+        }
     }];
 }
 
@@ -329,6 +332,36 @@
         }
     }
     return pageMode;
+}
+
+- (PSPDFSettingsOptions)settingsOptions:(nullable NSArray <NSString *> *)options {
+    if ((id)options == NSNull.null || !options || options.count == 0) {
+        return PSPDFSettingsOptionDefault;
+    }
+
+    PSPDFSettingsOptions finalOptions = 0;
+
+    for (NSString *option in options) {
+        if ([option isEqualToString:@"scrollDirection"]) {
+            finalOptions |= PSPDFSettingsOptionScrollDirection;
+        } else if ([option isEqualToString:@"pageTransition"]) {
+            finalOptions |= PSPDFSettingsOptionPageTransition;
+        } else if ([option isEqualToString:@"appearance"]) {
+            finalOptions |= PSPDFSettingsOptionAppearance;
+        } else if ([option isEqualToString:@"brightness"]) {
+            finalOptions |= PSPDFSettingsOptionBrightness;
+        } else if ([option isEqualToString:@"pageMode"]) {
+            finalOptions |= PSPDFSettingsOptionPageMode;
+        } else if ([option isEqualToString:@"spreadFitting"]) {
+            finalOptions |= PSPDFSettingsOptionSpreadFitting;
+        }
+    }
+
+    if (finalOptions == 0) {
+        finalOptions = PSPDFSettingsOptionDefault;
+    }
+
+    return finalOptions;
 }
 
 - (void)setToolbarTitle:(NSString *)toolbarTitle {

--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -135,8 +135,8 @@
         if (dictionary[@"isFirstPageAlwaysSingle"]) {
             builder.firstPageAlwaysSingle = [dictionary[@"isFirstPageAlwaysSingle"] boolValue];
         }
-        if (dictionary[@"settingsMenuItems"]) {
-            builder.settingsOptions = [self settingsOptions:dictionary[@"settingsMenuItems"]];
+        if (dictionary[@"iOSSettingsMenuItems"]) {
+            builder.settingsOptions = [self settingsOptions:dictionary[@"iOSSettingsMenuItems"]];
         }
     }];
 }
@@ -340,7 +340,6 @@
     }
 
     PSPDFSettingsOptions finalOptions = 0;
-
     for (NSString *option in options) {
         if ([option isEqualToString:@"scrollDirection"]) {
             finalOptions |= PSPDFSettingsOptionScrollDirection;
@@ -354,9 +353,12 @@
             finalOptions |= PSPDFSettingsOptionPageMode;
         } else if ([option isEqualToString:@"spreadFitting"]) {
             finalOptions |= PSPDFSettingsOptionSpreadFitting;
+        } else {
+            NSLog(@"WARNING: '%@' is an invalid settings option. It will be ignored.", option);
         }
     }
 
+    // If no options were passed, we use the default setting options.
     if (finalOptions == 0) {
         finalOptions = PSPDFSettingsOptionDefault;
     }

--- a/lib/configuration_options.dart
+++ b/lib/configuration_options.dart
@@ -89,7 +89,7 @@ const String iOSAllowToolbarTitleChange = "allowToolbarTitleChange";
 const String toolbarTitle = "toolbarTitle";
 
 const String androidSettingsMenuItems = "settingsMenuItems";
-const String iOSSettingsMenuItems = "settingsMenuItems";
+const String iOSSettingsMenuItems = "iOSSettingsMenuItems";
 
 const String showActionNavigationButtons = "showActionNavigationButtons";
 const String iOSShowActionNavigationButtonLabels = "iOSShowActionNavigationButtonLabels";
@@ -98,4 +98,4 @@ const String pageLayoutMode = "pageLayoutMode";
 const String pageLayoutModeAutomatic = "automatic";
 const String pageLayoutModeSingle = "single";
 const String pageLayoutModeDouble = "double";
-const String iOSIsFirstPageAlwaysSingle = "isFirstPageAlwaysSingle";
+const String isFirstPageAlwaysSingle = "isFirstPageAlwaysSingle";

--- a/lib/configuration_options.dart
+++ b/lib/configuration_options.dart
@@ -89,6 +89,7 @@ const String iOSAllowToolbarTitleChange = "allowToolbarTitleChange";
 const String toolbarTitle = "toolbarTitle";
 
 const String androidSettingsMenuItems = "settingsMenuItems";
+const String iOSSettingsMenuItems = "settingsMenuItems";
 
 const String showActionNavigationButtons = "showActionNavigationButtons";
 const String iOSShowActionNavigationButtonLabels = "iOSShowActionNavigationButtonLabels";

--- a/lib/configuration_options.dart
+++ b/lib/configuration_options.dart
@@ -92,3 +92,9 @@ const String androidSettingsMenuItems = "settingsMenuItems";
 
 const String showActionNavigationButtons = "showActionNavigationButtons";
 const String iOSShowActionNavigationButtonLabels = "iOSShowActionNavigationButtonLabels";
+
+const String pageLayoutMode = "pageLayoutMode";
+const String pageLayoutModeAutomatic = "automatic";
+const String pageLayoutModeSingle = "single";
+const String pageLayoutModeDouble = "double";
+const String iOSIsFirstPageAlwaysSingle = "isFirstPageAlwaysSingle";

--- a/lib/configuration_options.dart
+++ b/lib/configuration_options.dart
@@ -88,7 +88,7 @@ const String iOSAllowToolbarTitleChange = "allowToolbarTitleChange";
 
 const String toolbarTitle = "toolbarTitle";
 
-const String androidSettingsMenuItems = "settingsMenuItems";
+const String androidSettingsMenuItems = "androidSettingsMenuItems";
 const String iOSSettingsMenuItems = "iOSSettingsMenuItems";
 
 const String showActionNavigationButtons = "showActionNavigationButtons";


### PR DESCRIPTION
Solves #45 

---

# Details

This PR exposes [page mode on iOS](https://pspdfkit.com/api/ios/Classes/PSPDFConfiguration.html#/c:objc(cs)PSPDFConfiguration(py)pageMode) and [page layout mode on Android](https://pspdfkit.com/api/android/reference/com/pspdfkit/configuration/page/PageLayoutMode.html).

This PR also exposes [is first page always single](https://pspdfkit.com/api/ios/Classes/PSPDFConfiguration.html#/c:objc(cs)PSPDFConfiguration(py)firstPageAlwaysSingle) configuration option.

## Usage:

```dart
Pspdfkit.present(tempDocumentPath, {
  pageLayoutMode: 'automatic',
  iOSIsFirstPageAlwaysSingle: false
});
```

<img width="1109" alt="Screen Shot 2019-11-02 at 11 08 36 AM" src="https://user-images.githubusercontent.com/7443038/68072985-173ce580-fd62-11e9-9d5d-f1c72a0f2182.png">

# Acceptance Criteria

- [x] The Page Mode configuration option is exposed on iOS.
- [x] The is first page always single configuration option is exposed on iOS.
- [x] The Page Layout Mode configuration option is exposed on Android.
- [x] The is first page always single configuration option is exposed on Android.
