### PR TITLE
Update Android part to PSPDFKit 6.1.1

### DIFF
--- a/android/config.gradle
+++ b/android/config.gradle
@@ -36,7 +36,7 @@ if (pspdfkitPassword == null || pspdfkitPassword == '') {
 
 ext.pspdfkitVersion = localProperties.getProperty('pspdfkit.version')
 if (pspdfkitVersion == null || pspdfkitVersion == '') {
-    ext.pspdfkitVersion = '6.0.0'
+    ext.pspdfkitVersion = '6.1.1'
 }
 
 def pspdfkitIsDemo = localProperties.getProperty('pspdfkit.demo')
@@ -50,11 +50,11 @@ ext.pspdfkitMavenModuleName = (pspdfkitIsDemo && !useUnifiedBinaries(ext.pspdfki
 
 ext.pspdfkitFlutterVersion = '1.0.0-SNAPSHOT'
 
-ext.androidCompileSdkVersion = 28
-ext.androidBuildToolsVersion = '28.0.3'
+ext.androidCompileSdkVersion = 29
+ext.androidBuildToolsVersion = '29.0.1'
 ext.androidMinSdkVersion = 19
-ext.androidTargetSdkVersion = 28
-ext.androidGradlePluginVersion = '3.4.2'
+ext.androidTargetSdkVersion = 29
+ext.androidGradlePluginVersion = '3.5.2'
 
 // Returns true when version1 is more recent than or equals to version2.
 boolean isMoreRecentOrEqual(String version1, String version2) {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pspdfkit_example
 description: Demonstrates how to use the pspdfkit plugin.
-version: 1.7.0
+version: 1.8.0
 author: PSPDFKit
 homepage: https://pspdfkit.com/
 environment:

--- a/lib/pspdfkit.dart
+++ b/lib/pspdfkit.dart
@@ -56,7 +56,7 @@ class Pspdfkit {
   
   /// Checks the external storage permission for writing on Android only.
   static Future<bool> checkAndroidWriteExternalStoragePermission() async {
-    _channel.invokeMethod(
+    return _channel.invokeMethod(
         "checkPermission",
         {"permission": "WRITE_EXTERNAL_STORAGE"}
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pspdfkit_flutter
 description: PSPDFKit flutter plugin.
-version: 1.7.0
+version: 1.8.0
 author: PSPDFKit
 homepage: https://pspdfkit.com/
 environment:


### PR DESCRIPTION
## Resolves https://github.com/PSPDFKit/pspdfkit-flutter/issues/52

# Details
Update Android part to PSPDFKit for Android `6.1.1`
Update compile Sdk Version to `29`
Update Android build tool version to `29.0.1`
Update target Sdk version to `29`
Update Gradle plugin version to `3.5.2`

Fix Dart method `Pspdfkit#checkAndroidWriteExternalStoragePermission()`
Bump wrapper version to `1.8.0`
Bump example version to `1.8.0`

# Acceptance Criteria

- [x] Before merging retest all the examples to make sure that they work on both Android and iOS.
