### PR TITLE
Reload the PSPDFViewController after applying Instant JSON payload

### DIFF
--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -54,6 +54,7 @@
         if (!success) {
             result([FlutterError errorWithCode:@"" message:@"Error while importing document Instant JSON." details:nil]);
         } else {
+            [self.pdfViewController reloadData];
             result(@(YES));
         }
     } else if ([@"exportInstantJson" isEqualToString:call.method]) {


### PR DESCRIPTION
# Details

## How to Reproduce:

- Launch the example project and open the "Import Instant Document JSON" example.

## Expected:

The newly imported annotation should be visible.

## Actual:

The newly imported annotation is not visible.

| **Before** | **After** |
| --- | --- | 
| ![before](https://user-images.githubusercontent.com/7443038/72818506-97743800-3c39-11ea-872a-ad51c307f618.gif) | ![after](https://user-images.githubusercontent.com/7443038/72818516-9cd18280-3c39-11ea-88e6-73bcf0f6de22.gif) |

# Acceptance Criteria

- [ ] Newly imported annotation via Instant Document JSON  should be visible.
- [ ] Before merging retest all the examples to make sure that they work on both Android and iOS.
