### PR TITLE
Add Annotation API

### DIFF
--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -338,7 +338,7 @@
     }
 }
 
-# pragma mark - Toolbar Customization
+#pragma mark - Customize the Toolbar
 
 - (void)setLeftBarButtonItems:(nullable NSArray <NSString *> *)items {
     if ((id)items == NSNull.null || !items || items.count == 0) {

--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -87,7 +87,8 @@
         NSString *documentPath = call.arguments[@"document"];
 
         if (documentPath == nil || documentPath.length <= 0) {
-            result([FlutterError errorWithCode:@"" message:@"Document path may not be nil or empty." details:nil]);
+            FlutterError *error = [FlutterError errorWithCode:@"" message:@"Document path may not be nil or empty." details:nil];
+            result(error);
             return;
         }
 
@@ -369,17 +370,19 @@
     [self.pdfViewController.navigationItem setRightBarButtonItems:[rightItems copy] animated:NO];
 }
 
-# pragma mark - Forms
+#pragma mark - Forms
 
 - (id)setFormFieldValue:(NSString *)value forFieldWithFullyQualifiedName:(NSString *)fullyQualifiedName {
     PSPDFDocument *document = self.pdfViewController.document;
 
     if (!document || !document.isValid) {
-        return [FlutterError errorWithCode:@"" message:@"PDF document not found or is invalid." details:nil];
+        FlutterError *error = [FlutterError errorWithCode:@"" message:@"PDF document not found or is invalid." details:nil];
+        return error;
     }
 
     if (fullyQualifiedName == nil || fullyQualifiedName.length == 0) {
-        return [FlutterError errorWithCode:@"" message:@"Fully qualified name may not be nil or empty." details:nil];
+        FlutterError *error = [FlutterError errorWithCode:@"" message:@"Fully qualified name may not be nil or empty." details:nil];
+        return error;
     }
 
     BOOL success = NO;
@@ -400,7 +403,8 @@
                 formElement.contents = value;
                 success = YES;
             } else if ([formElement isKindOfClass:PSPDFSignatureFormElement.class]) {
-                return [FlutterError errorWithCode:@"" message:@"Signature form elements are not supported." details:nil];
+                FlutterError *error = [FlutterError errorWithCode:@"" message:@"Signature form elements are not supported." details:nil];
+                return error;
             } else {
                 return @(NO);
             }
@@ -409,7 +413,8 @@
     }
 
     if (!success) {
-        return [FlutterError errorWithCode:@"" message:[NSString stringWithFormat:@"Error while searching for a form element with name %@.", fullyQualifiedName] details:nil];
+        FlutterError *error = [FlutterError errorWithCode:@"" message:[NSString stringWithFormat:@"Error while searching for a form element with name %@.", fullyQualifiedName] details:nil];
+        return error;
     }
 
     return @(YES);
@@ -417,7 +422,8 @@
 
 - (id)getFormFieldValueForFieldWithFullyQualifiedName:(NSString *)fullyQualifiedName {
     if (fullyQualifiedName == nil || fullyQualifiedName.length == 0) {
-        return [FlutterError errorWithCode:@"" message:@"Fully qualified name may not be nil or empty." details:nil];
+        FlutterError *error = [FlutterError errorWithCode:@"" message:@"Fully qualified name may not be nil or empty." details:nil];
+        return error;
     }
 
     PSPDFDocument *document = self.pdfViewController.document;
@@ -430,7 +436,8 @@
     }
 
     if (formFieldValue == nil) {
-        return [FlutterError errorWithCode:@"" message:[NSString stringWithFormat:@"Error while searching for a form element with name %@.", fullyQualifiedName] details:nil];
+        FlutterError *error = [FlutterError errorWithCode:@"" message:[NSString stringWithFormat:@"Error while searching for a form element with name %@.", fullyQualifiedName] details:nil];
+        return error;
     }
 
     return formFieldValue;

--- a/lib/pspdfkit.dart
+++ b/lib/pspdfkit.dart
@@ -51,20 +51,20 @@ class Pspdfkit {
   static Future<String> exportInstantJson() async => _channel.invokeMethod('exportInstantJson');
 
   /// Adds the given annotation to the presented document. 
-  /// `jsonAnnotation` can either be a JSON String or a valid JSON dictionary.
+  /// `jsonAnnotation` can either be a JSON string or a valid JSON dictionary.
   Future<bool> addAnnotation(dynamic jsonAnnotation) async => 
       _channel.invokeMethod('addAnnotation', <String, dynamic>{'jsonAnnotation': jsonAnnotation});
 
   /// Removes the given annotation from the presented document. 
-  /// `jsonAnnotation` can either be a JSON String or a valid JSON dictionary.
+  /// `jsonAnnotation` can either be a JSON string or a valid JSON dictionary.
   Future<bool> removeAnnotation(dynamic jsonAnnotation) async => 
       _channel.invokeMethod('removeAnnotation', <String, dynamic>{'jsonAnnotation': jsonAnnotation});
   
-  /// Returns a list of JSON Strings for all the annotations of the given `type` on the given `pageIndex`.
+  /// Returns a list of JSON dictionaries for all the annotations of the given `type` on the given `pageIndex`.
   Future<dynamic> getAnnotations(int pageIndex, String type) async =>
       _channel.invokeMethod<dynamic>('getAnnotations', <String, dynamic>{'pageIndex': pageIndex, 'type': type});
 
-  /// Returns a list of JSON Strings for all the unsaved annotations in the presented document.
+  /// Returns a list of JSON dictionaries for all the unsaved annotations in the presented document.
   Future<dynamic> getAllUnsavedAnnotations() async => _channel.invokeMethod<dynamic>('getAllUnsavedAnnotations');
 
   /// Saves the document back to its original location if it has been changed.

--- a/lib/pspdfkit.dart
+++ b/lib/pspdfkit.dart
@@ -50,6 +50,17 @@ class Pspdfkit {
   /// Exports Instant document JSON from the presented document.
   static Future<String> exportInstantJson() async => _channel.invokeMethod('exportInstantJson');
 
+  Future<bool> addAnnotation(dynamic jsonAnnotation) async => 
+      _channel.invokeMethod('addAnnotation', <String, dynamic>{'jsonAnnotation': jsonAnnotation});
+
+  Future<bool> removeAnnotation(String jsonAnnotation) async => 
+      _channel.invokeMethod('removeAnnotation', <String, String>{'jsonAnnotation': jsonAnnotation});
+  
+  Future<dynamic> getAnnotations(int pageIndex, String type) async =>
+      _channel.invokeMethod<dynamic>('getAnnotations', <String, dynamic>{'pageIndex': pageIndex, 'type': type});
+
+  Future<dynamic> getAllUnsavedAnnotations() async => _channel.invokeMethod<dynamic>('getAllUnsavedAnnotations');
+
   /// Saves the document back to its original location if it has been changed.
   /// If there were no changes to the document, the document file will not be modified.
   static Future<bool> save() async => _channel.invokeMethod('save');

--- a/lib/pspdfkit.dart
+++ b/lib/pspdfkit.dart
@@ -57,7 +57,7 @@ class Pspdfkit {
 
   /// Removes the given annotation from the presented document. 
   /// `jsonAnnotation` can either be a JSON String or a valid JSON dictionary.
-  Future<bool> removeAnnotation(String jsonAnnotation) async => 
+  Future<bool> removeAnnotation(dynamic jsonAnnotation) async => 
       _channel.invokeMethod('removeAnnotation', <String, dynamic>{'jsonAnnotation': jsonAnnotation});
   
   /// Returns a list of JSON Strings for all the annotations of the given `type` on the given `pageIndex`.

--- a/lib/pspdfkit.dart
+++ b/lib/pspdfkit.dart
@@ -50,15 +50,21 @@ class Pspdfkit {
   /// Exports Instant document JSON from the presented document.
   static Future<String> exportInstantJson() async => _channel.invokeMethod('exportInstantJson');
 
+  /// Adds the given annotation to the presented document. 
+  /// `jsonAnnotation` can either be a JSON String or a valid JSON dictionary.
   Future<bool> addAnnotation(dynamic jsonAnnotation) async => 
       _channel.invokeMethod('addAnnotation', <String, dynamic>{'jsonAnnotation': jsonAnnotation});
 
+  /// Removes the given annotation from the presented document. 
+  /// `jsonAnnotation` can either be a JSON String or a valid JSON dictionary.
   Future<bool> removeAnnotation(String jsonAnnotation) async => 
-      _channel.invokeMethod('removeAnnotation', <String, String>{'jsonAnnotation': jsonAnnotation});
+      _channel.invokeMethod('removeAnnotation', <String, dynamic>{'jsonAnnotation': jsonAnnotation});
   
+  /// Returns a list of JSON Strings for all the annotations of the given `type` on the given `pageIndex`.
   Future<dynamic> getAnnotations(int pageIndex, String type) async =>
       _channel.invokeMethod<dynamic>('getAnnotations', <String, dynamic>{'pageIndex': pageIndex, 'type': type});
 
+  /// Returns a list of JSON Strings for all the unsaved annotations in the presented document.
   Future<dynamic> getAllUnsavedAnnotations() async => _channel.invokeMethod<dynamic>('getAllUnsavedAnnotations');
 
   /// Saves the document back to its original location if it has been changed.


### PR DESCRIPTION
WIP PR for #33 

# Details

Adds API for  `addAnnotation`, `removeAnnotation`, `getAnnotations` and `getAllUnsavedAnnotations`.

Done:
* iOS implementation.
* Flutter API.

TODO:
* Example.
* Document type strings.
* Android implementation.

# Acceptance Criteria

- [ ] Before merging retest all the examples to make sure that they work on both Android and iOS.
