### PR TITLE
Update PSPDFKit for Android to 6.4

### DIFF
--- a/android/config.gradle
+++ b/android/config.gradle
@@ -36,7 +36,7 @@ if (pspdfkitPassword == null || pspdfkitPassword == '') {
 
 ext.pspdfkitVersion = localProperties.getProperty('pspdfkit.version')
 if (pspdfkitVersion == null || pspdfkitVersion == '') {
-    ext.pspdfkitVersion = '6.2.0'
+    ext.pspdfkitVersion = '6.4.0'
 }
 
 def pspdfkitIsDemo = localProperties.getProperty('pspdfkit.demo')
@@ -54,7 +54,7 @@ ext.androidCompileSdkVersion = 29
 ext.androidBuildToolsVersion = '29.0.1'
 ext.androidMinSdkVersion = 19
 ext.androidTargetSdkVersion = 29
-ext.androidGradlePluginVersion = '3.5.3'
+ext.androidGradlePluginVersion = '3.6.3'
 
 // Returns true when version1 is more recent than or equals to version2.
 boolean isMoreRecentOrEqual(String version1, String version2) {

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
# Details

This PR updates the Flutter wrapper to PSPDFKit 6.4 for Android

# Acceptance Criteria

- [x] Before merging retest all the examples to make sure that they work on both Android and iOS.
