### PR TITLE
Update PSPDFKit for Android to 6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Let's create a simple app that integrates PSPDFKit and uses the Flutter pspdfkit
 ```local.properties
 sdk.dir=/path/to/your/Android/sdk
 flutter.sdk=/path/to/your/flutter/sdk
-pspdfkit.password=YOUR_MAVEN_KEY_GOES_HERE
 flutter.buildMode=debug
 ```
 
@@ -398,17 +397,3 @@ The verbose mode of flutter doctor is even more helpful; it prints out extensive
 ### CocoaPods Conflicts With Asdf
 
 If [asdf](https://github.com/asdf-vm/asdf) is installed in your machine it might create problems when running Cocoapods, and Flutter will erroneusly suggest to install CocoaPods via brew with `brew install cocoapods`. This won't work because for this specific configuration CocoaPods needs to be installed via [RubyGems](https://rubygems.org/). To fix this configuration issue just type `gem install cocoapods && pod setup`.
-
-## Error When Running on Android: Cannot Find Symbol `PSPDFKit`
-
-Verify that your Maven key has been correctly inserted in your `myapp/android/local.properties`
-
-```local.properties
-sdk.dir=/path/to/your/Android/sdk
-flutter.sdk=/path/to/your/flutter/sdk
-pspdfkit.password=YOUR_MAVEN_KEY_GOES_HERE
-flutter.buildMode=debug
-```
-
-Make sure that the Maven key has not been confused with the license key. The Maven key is generally shorter and for demo licenses it starts with `TRIAL-`.
-

--- a/android/README.md
+++ b/android/README.md
@@ -18,11 +18,7 @@ Upon opening the Flutter example project for the first time inside Android Studi
 sdk.dir=/path/to/your/android/sdk
 ndk.dir=/path/to/your/android/sdk/ndk-bundle
 flutter.sdk=/path/to/your/flutter/sdk
-
-pspdfkit.password=YOUR_PSPDFKIT_MAVEN_PASSWORD
 ```
-
-The `pspdfkit.password` should be set to the PSPDFKit Maven download credentials that you received while [requesting a PSPDFKit demo](https://pspdfkit.com/try) or from your [PSPDFKit customer portal](https://customers.pspdfkit.com).
 
 ## Troubleshooting
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,10 +26,6 @@ rootProject.allprojects {
     repositories {
         maven {
             url pspdfkitMavenUrl
-            credentials {
-                username pspdfkitUsername
-                password pspdfkitPassword
-            }
         }
         google()
         jcenter()

--- a/android/config.gradle
+++ b/android/config.gradle
@@ -38,19 +38,3 @@ ext.androidBuildToolsVersion = '29.0.1'
 ext.androidMinSdkVersion = 19
 ext.androidTargetSdkVersion = 29
 ext.androidGradlePluginVersion = '3.6.3'
-
-// Returns true when version1 is more recent than or equals to version2.
-boolean isMoreRecentOrEqual(String version1, String version2) {
-    [version1,version2]*.tokenize('.')*.collect { it as int }.with { u, v ->
-       Integer result = [u,v].transpose().findResult{ x,y -> x <=> y ?: null } ?: u.size() <=> v.size()
-       return (result == 1 || result == 0)
-    } 
-}
-
-// Starting from version 5.5.0 we moved to a simplified model
-// that uses unified binaries when on trial and in production
-// https://pspdfkit.com/blog/2019/pspdfkit-android-5-5/#simplified-integration
-boolean useUnifiedBinaries(String version) {
-String versionUnified = '5.5.0'
-return isMoreRecentOrEqual(version, versionUnified)
-}

--- a/android/config.gradle
+++ b/android/config.gradle
@@ -24,29 +24,12 @@ if (pspdfkitMavenUrl == null || pspdfkitMavenUrl == '') {
     ext.pspdfkitMavenUrl = 'https://customers.pspdfkit.com/maven/'
 }
 
-ext.pspdfkitUsername = localProperties.getProperty('pspdfkit.username')
-if (pspdfkitUsername == null || pspdfkitUsername == '') {
-    ext.pspdfkitUsername = 'pspdfkit'
-}
-
-ext.pspdfkitPassword = localProperties.getProperty('pspdfkit.password')
-if (pspdfkitPassword == null || pspdfkitPassword == '') {
-    throw new GradleException("PSPDFKit password was not specified. The password is required to download the PSPDFKit AAR file into your project. Please specify as pspdfkit.password inside the local.properties file.")
-}
-
 ext.pspdfkitVersion = localProperties.getProperty('pspdfkit.version')
 if (pspdfkitVersion == null || pspdfkitVersion == '') {
-    ext.pspdfkitVersion = '6.4.0'
+    ext.pspdfkitVersion = '6.5.0'
 }
 
-def pspdfkitIsDemo = localProperties.getProperty('pspdfkit.demo')
-if (pspdfkitIsDemo == null) {
-    pspdfkitIsDemo = pspdfkitPassword.startsWith('TRIAL-')
-} else {
-    pspdfkitIsDemo = Boolean.parseBoolean(pspdfkitIsDemo)
-}
-
-ext.pspdfkitMavenModuleName = (pspdfkitIsDemo && !useUnifiedBinaries(ext.pspdfkitVersion)) ? 'pspdfkit-demo' : 'pspdfkit'
+ext.pspdfkitMavenModuleName = 'pspdfkit'
 
 ext.pspdfkitFlutterVersion = '1.9.0-SNAPSHOT'
 

--- a/example/README.md
+++ b/example/README.md
@@ -11,7 +11,6 @@ This is a brief example of how to use the PSPDFKit with Flutter.
 ```local.properties
 sdk.dir=/path/to/your/Android/sdk
 flutter.sdk=/path/to/your/flutter/sdk
-pspdfkit.password=YOUR_PASSWORD_GOES_HERE
 flutter.buildMode=debug
 ```
 

--- a/example/android/local.properties.sample
+++ b/example/android/local.properties.sample
@@ -4,7 +4,3 @@ ndk.dir=/path/to/your/android/ndk
 sdk.dir=/path/to/your/android/sdk
 flutter.sdk=/path/to/your/flutter/sdk
 flutter.buildMode=debug
-
-# The Maven password you received while together with your PSPDFKit demo email, or your customer Maven password.
-# If you don't yet own a password, please head over to https://pspdfkit.com/try to request a demo.
-pspdfkit.password=


### PR DESCRIPTION
# Details

This PR updates the flutter wrapper for PSPDFKit 6.5 for Android. Furthermore, I removed the need for specifying a Maven password in the local.properties file and removed all mentioning of the password inside the READMEs. 

# Acceptance Criteria

- [x] Before merging retest all the examples to make sure that they work on both Android and iOS.
