### PR TITLE
Update for PSPDFKit 10.1 for iOS and Xcode 12.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,10 +213,10 @@ adb push /path/to/your/document.pdf /sdcard/document.pdf
 
 #### Requirements
 
- - Xcode 12
- - PSPDFKit 10.0.0 for iOS or later
- - Flutter 1.21.0-9.2.pre or later
- - CocoaPods 1.10.0.rc.1 or later (Update cocoapods with: `gem install cocoapods -v 1.10.0.rc.1`)
+ - The latest [Xcode](https://developer.apple.com/xcode/)
+ - PSPDFKit 10.1.0 for iOS or later
+ - Flutter 1.23.0-18.1.pre or later
+ - CocoaPods 1.10.0 or later (Update cocoapods with: `gem install cocoapods`)
 
 #### Getting Started
 

--- a/example/README.md
+++ b/example/README.md
@@ -12,10 +12,10 @@ This is a brief example of how to use the PSPDFKit with Flutter.
 
 ## iOS
 
-- Xcode 12
-- PSPDFKit 10.0.0 for iOS or later
-- Flutter 1.21.0-9.2.pre or later
-- CocoaPods 1.10.0.rc.1 or later (Update cocoapods with: `gem install cocoapods -v 1.10.0.rc.1`)
+- The latest [Xcode](https://developer.apple.com/xcode/)
+- PSPDFKit 10.1.0 for iOS or later
+- Flutter 1.23.0-18.1.pre or later
+- CocoaPods 1.10.0 or later (Update cocoapods with: `gem install cocoapods`)
 
 # Running the Example Project
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pspdfkit_example
 description: Demonstrates how to use the pspdfkit plugin.
-version: 1.10.0
+version: 1.10.2
 author: PSPDFKit
 homepage: https://pspdfkit.com/
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pspdfkit_flutter
 description: PSPDFKit flutter plugin.
-version: 1.10.0
+version: 1.10.2
 author: PSPDFKit
 homepage: https://pspdfkit.com/
 environment:


### PR DESCRIPTION
# Details

This PR updates the plugin for PSPDFKit 10.1 for iOS, Xcode 12.2, and Flutter 1.23.0-18.1.pre.pre.

# Acceptance Criteria

- [x] Before merging retest all the examples to make sure that they work on both Android and iOS.
