### PR TITLE
Remove the need to update the version in two places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Next Release
+
+- Fixes versioning system to not require a manual update in two places. (#80)
+- Updates Gradle version and enable AndroidX for Android plugin and example. (#80)
+- Changes open source license to modified BSD instead of Apache. (#79)
+
 ## [1.10.3] - 11 Jan 2021
 
 - Updates copyright year to 2021. (#75)

--- a/android/config.gradle
+++ b/android/config.gradle
@@ -7,15 +7,16 @@
  *   This notice may not be removed from this file.
  */
 
-@Grab('org.yaml:snakeyaml:1.17')
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "org.yaml:snakeyaml:1.27"
+    }
+}
 
-import groovy.yaml
-
-Yaml parser = new Yaml()
-List example = parser.load(("example.yaml" as File).text)
-
-example.each{println it.subject}
-
+import org.yaml.snakeyaml.Yaml
 
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
@@ -42,13 +43,14 @@ if (pspdfkitVersion == null || pspdfkitVersion == '') {
 
 ext.pspdfkitMavenModuleName = 'pspdfkit'
 
-// Get our library version from the pubspec.yaml file.
-def pubspecFile = rootProject.file('../pubspec.yaml')
+// Get our library version from the top level pubspec.yaml file.
+def pubspecFilePath = '../pubspec.yaml'
+def pubspecFile = rootProject.file(pubspecFilePath)
 if (!pubspecFile.exists()) {
-    throw new GradleException("pubspec.yaml not found")
+    throw new GradleException("'pubspec.yaml' file not found. Expected at the top level of the Flutter repository.")
 }
-
-ext.pspdfkitFlutterVersion = '1.10.3'
+def pubspecYaml = new Yaml().load( pubspecFile.newInputStream() )
+ext.pspdfkitFlutterVersion = pubspecYaml.version
 
 ext.androidCompileSdkVersion = 29
 ext.androidBuildToolsVersion = '29.0.1'

--- a/android/config.gradle
+++ b/android/config.gradle
@@ -49,7 +49,7 @@ def pubspecFile = rootProject.file(pubspecFilePath)
 if (!pubspecFile.exists()) {
     throw new GradleException("'pubspec.yaml' file not found. Expected at the top level of the Flutter repository.")
 }
-def pubspecYaml = new Yaml().load( pubspecFile.newInputStream() )
+def pubspecYaml = new Yaml().load(pubspecFile.newInputStream())
 ext.pspdfkitFlutterVersion = pubspecYaml.version
 
 ext.androidCompileSdkVersion = 29

--- a/android/config.gradle
+++ b/android/config.gradle
@@ -56,4 +56,4 @@ ext.androidCompileSdkVersion = 29
 ext.androidBuildToolsVersion = '29.0.1'
 ext.androidMinSdkVersion = 19
 ext.androidTargetSdkVersion = 29
-ext.androidGradlePluginVersion = '3.6.3'
+ext.androidGradlePluginVersion = '4.1.1'

--- a/android/config.gradle
+++ b/android/config.gradle
@@ -6,6 +6,17 @@
  *   UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
  *   This notice may not be removed from this file.
  */
+
+@Grab('org.yaml:snakeyaml:1.17')
+
+import groovy.yaml
+
+Yaml parser = new Yaml()
+List example = parser.load(("example.yaml" as File).text)
+
+example.each{println it.subject}
+
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
@@ -30,6 +41,12 @@ if (pspdfkitVersion == null || pspdfkitVersion == '') {
 }
 
 ext.pspdfkitMavenModuleName = 'pspdfkit'
+
+// Get our library version from the pubspec.yaml file.
+def pubspecFile = rootProject.file('../pubspec.yaml')
+if (!pubspecFile.exists()) {
+    throw new GradleException("pubspec.yaml not found")
+}
 
 ext.pspdfkitFlutterVersion = '1.10.3'
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,2 +1,17 @@
-org.gradle.jvmargs=-Xmx1536M
+## For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+#
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+#Mon Feb 01 09:50:51 GMT 2021
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.configureondemand=false
+org.gradle.jvmargs=-Xmx1536M

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jul 16 16:27:42 CEST 2018
+#Wed Jan 27 11:51:31 GMT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jan 27 11:51:31 GMT 2021
+#Mon Feb 01 16:17:50 GMT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -44,7 +44,7 @@ flutter {
 }
 
 dependencies {
-    compile 'com.android.support:multidex:1.0.3'
+    implementation 'com.android.support:multidex:1.0.3'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.jvmargs=-Xmx1536M
 org.gradle.configureondemand=false
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableR8=true
+android.enableD8=true

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -2,4 +2,3 @@ org.gradle.jvmargs=-Xmx1536M
 org.gradle.configureondemand=false
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableD8=true

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 23 08:50:38 CEST 2017
+#Tue Feb 02 09:21:10 GMT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
# Details

When doing a version bump, we should keep the values in `pubspec.yaml` and `config.gradle` for android the same. 
This PR uses a gradle Yaml library to parse the pubspec version and use it in the gradle config step.

I am also updating the gradle version and have applied some auto generated android studio fixes (commented) related to migrating to AndroidX.

# Acceptance Criteria

- [ ] Before merging retest all the examples to make sure that they work on both Android and iOS.
