### PR TITLE
Update for PSPDFKit 10.2 for iOS and Xcode 12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## Next Release
 
-- Fixes versioning system to not require a manual update in two places. (#80)
+## [1.10.4] - 2 Feb 2021
+
 - Updates Gradle version and enable AndroidX for Android plugin and example. (#80)
+- Updates for PSPDFKit 10.2 for iOS and Xcode 12.4.(#81)
 - Changes open source license to modified BSD instead of Apache. (#79)
+- Fixes versioning system to not require a manual update in two places. (#80)
 
 ## [1.10.3] - 11 Jan 2021
 

--- a/README.md
+++ b/README.md
@@ -214,9 +214,9 @@ adb push /path/to/your/document.pdf /sdcard/document.pdf
 #### Requirements
 
  - The latest [Xcode](https://developer.apple.com/xcode/)
- - PSPDFKit 10.1.0 for iOS or later
- - Flutter 1.23.0-18.1.pre or later
- - CocoaPods 1.10.0 or later (Update cocoapods with: `gem install cocoapods`)
+ - PSPDFKit 10.2.0 for iOS or later
+ - Flutter 1.22.6 or later
+ - CocoaPods 1.10.1 or later (Update cocoapods with: `gem install cocoapods`)
 
 #### Getting Started
 

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -213,11 +213,13 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
+				"${PODS_ROOT}/../Flutter/Flutter.framework",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/PSPDFKit/PSPDFKit.framework/PSPDFKit",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/PSPDFKitUI/PSPDFKitUI.framework/PSPDFKitUI",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PSPDFKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PSPDFKitUI.framework",
 			);

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pspdfkit_example
 description: Demonstrates how to use the pspdfkit plugin.
-version: 1.10.3
+version: 1.10.4
 author: PSPDFKit
 homepage: https://pspdfkit.com/
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pspdfkit_flutter
 description: PSPDFKit flutter plugin.
-version: 1.10.3
+version: 1.10.4
 author: PSPDFKit
 homepage: https://pspdfkit.com/
 environment:


### PR DESCRIPTION
# Details

This PR updates the plugin for PSPDFKit 10.2 for iOS, Xcode 12.4, Flutter 1.22.6, and CocoaPods 1.10.1

# Acceptance Criteria

- [x] Before merging retest all the examples to make sure that they work on both Android and iOS.
