### PR TITLE
Update imports for the latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Next Release
 
+## [1.10.6] - 9 Feb 2021
+
+- Adds “Migrating from Version 1.10.3” section in the main README. (#83)
+- Fixes import in getting started code snippets for iOS and Android. (#83)
+- Updates the requirements in the iOS README. (#83)
+
 ## [1.10.5] - 2 Feb 2021
 
 - Fixes the license key in the example project. (#82)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ android {
 ```dart
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:pspdfkit_flutter/pspdfkit.dart';
+import 'package:pspdfkit_flutter/src/main.dart';
 
 void main() => runApp(new MyApp());
 
@@ -281,7 +281,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:path_provider/path_provider.dart';
-import 'package:pspdfkit_flutter/pspdfkit.dart';
+import 'package:pspdfkit_flutter/src/main.dart';
 
 const String DOCUMENT_PATH = 'PDFs/PSPDFKit.pdf';
 const String PSPDFKIT_FLUTTER_PLUGIN_TITLE = 'PSPDFKit Flutter Plugin example app';

--- a/README.md
+++ b/README.md
@@ -398,6 +398,40 @@ showDocument() async {
 
 Please ensure [you signed our CLA](https://pspdfkit.com/guides/web/current/miscellaneous/contributing/) so we can accept your contributions.
 
+# Migrating from Version 1.10.3
+
+Q: I updated the Flutter plugin and I am getting the following error:
+
+```bash
+lib/main.dart:8:8: Error: Error when reading '../../.pub-cache/git/pspdfkit-flutter-b6241555b1ee3e816a0dce65145991c1a4477d94/lib/pspdfkit.dart': No such file or directory
+import 'package:pspdfkit_flutter/pspdfkit.dart';                        
+       ^                                                                
+lib/main.dart:37:7: Error: The getter 'Pspdfkit' isn't defined for the class '_MyAppState'.
+ - '_MyAppState' is from 'package:myapp/main.dart' ('lib/main.dart').   
+Try correcting the name to the name of an existing getter, or defining a getter or field named 'Pspdfkit'.
+      Pspdfkit.present(tempDocumentPath);                               
+      ^^^^^^^^                                                          
+lib/main.dart:58:32: Error: The getter 'Pspdfkit' isn't defined for the class '_MyAppState'.
+ - '_MyAppState' is from 'package:myapp/main.dart' ('lib/main.dart').   
+Try correcting the name to the name of an existing getter, or defining a getter or field named 'Pspdfkit'.
+      frameworkVersion = await Pspdfkit.frameworkVersion;               
+                               ^^^^^^^^                                 
+lib/main.dart:73:5: Error: The getter 'Pspdfkit' isn't defined for the class '_MyAppState'.
+ - '_MyAppState' is from 'package:myapp/main.dart' ('lib/main.dart').   
+Try correcting the name to the name of an existing getter, or defining a getter or field named 'Pspdfkit'.
+    Pspdfkit.setLicenseKey("YOUR_LICENSE_KEY_GOES_HERE");               
+    ^^^^^^^^                                                            
+                                                                        
+                                                                        
+FAILURE: Build failed with an exception. 
+````
+A: If you were using version [1.10.3](https://github.com/PSPDFKit/pspdfkit-flutter/releases/tag/1.10.3) or earlier, you will need to update the imports in your Dart files like so:
+
+```diff
+- import 'package:pspdfkit_flutter/pspdfkit.dart';
++ import 'package:pspdfkit_flutter/src/main.dart';
+```
+
 # Troubleshooting
 
 ## Flutter Updates

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pspdfkit_example
 description: Demonstrates how to use the pspdfkit plugin.
-version: 1.10.5
+version: 1.10.6
 author: PSPDFKit
 homepage: https://pspdfkit.com/
 environment:

--- a/ios/README.md
+++ b/ios/README.md
@@ -2,10 +2,10 @@
 
 ## Requirements
 
-* Flutter SDK.
-* Xcode 10.1 or later.
-* PSPDFKit 8 for iOS
-* CocoaPods 1.5.3 or later.
+ - The latest [Xcode](https://developer.apple.com/xcode/)
+ - PSPDFKit 10.2.0 for iOS or later
+ - Flutter 1.22.6 or later
+ - CocoaPods 1.10.1 or later (Update cocoapods with: `gem install cocoapods`)
 
 ## Setup
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pspdfkit_flutter
 description: PSPDFKit flutter plugin.
-version: 1.10.5
+version: 1.10.6
 author: PSPDFKit
 homepage: https://pspdfkit.com/
 environment:


### PR DESCRIPTION
Solves https://github.com/PSPDFKit/PSPDFKit/issues/28037

---

# Details

What this PR does:

- [x] Fixes import in getting started code snippets for iOS and Android.
- [x] Updates the requirements in the iOS README.
- [x] Adds “Migrating from Version 1.10.3” section in the main README.

# Acceptance Criteria

- [x] Before merging, retest all the examples to make sure that they work on both Android and iOS.
- [x] Before merging, make sure that everything works in a newly created Flutter project on both Android and iOS. 
